### PR TITLE
Switch back to the `workspace.devfile.io` apiGroup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,11 +56,11 @@ mkdir -p "${BASE_DIR}/generated"
 operator-sdk generate k8s
 operator-sdk generate crds
 yq '.spec.validation.openAPIV3Schema' \
-  "${BASE_DIR}/deploy/crds/devfile.io_devworkspaces_crd.yaml" \
+  "${BASE_DIR}/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml" \
   > "${BASE_DIR}/schemas/devworkspace.json"
 
 yq '.spec.validation.openAPIV3Schema' \
-  "${BASE_DIR}/deploy/crds/devfile.io_devworkspacetemplates_crd.yaml" \
+  "${BASE_DIR}/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml" \
   > "${BASE_DIR}/schemas/devworkspace-template.json"
 
 transform()

--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: devworkspaces.devfile.io
+  name: devworkspaces.workspace.devfile.io
 spec:
-  group: devfile.io
+  group: workspace.devfile.io
   names:
     kind: DevWorkspace
     listKind: DevWorkspaceList

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: devworkspacetemplates.devfile.io
+  name: devworkspacetemplates.workspace.devfile.io
 spec:
-  group: devfile.io
+  group: workspace.devfile.io
   names:
     kind: DevWorkspaceTemplate
     listKind: DevWorkspaceTemplateList

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -55,7 +55,7 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - devfile.io
+  - workspace.devfile.io
   resources:
   - '*'
   verbs:

--- a/pkg/apis/workspaces/v1alpha1/doc.go
+++ b/pkg/apis/workspaces/v1alpha1/doc.go
@@ -1,4 +1,4 @@
 // Package v1alpha1 contains API Schema definitions for the org v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=devfile.io
+// +groupName=workspace.devfile.io
 package v1alpha1

--- a/pkg/apis/workspaces/v1alpha1/register.go
+++ b/pkg/apis/workspaces/v1alpha1/register.go
@@ -2,7 +2,7 @@
 
 // Package v1alpha1 contains API Schema definitions for the org v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=devfile.io
+// +groupName=workspace.devfile.io
 package v1alpha1
 
 import (
@@ -12,7 +12,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "devfile.io", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "workspace.devfile.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/samples/custom.devworkspace.yaml
+++ b/samples/custom.devworkspace.yaml
@@ -1,5 +1,5 @@
 kind: "DevWorkspace"
-apiVersion: "devfile.io/v1alpha1"
+apiVersion: "workspace.devfile.io/v1alpha1"
 metadata:
   "name": "myWorkspace"
 spec:

--- a/samples/example.devworkspace.yaml
+++ b/samples/example.devworkspace.yaml
@@ -1,5 +1,5 @@
 kind: "DevWorkspace"
-apiVersion: "devfile.io/v1alpha1"
+apiVersion: "workspace.devfile.io/v1alpha1"
 metadata:
   "name": "myWorkspace"
 spec:

--- a/samples/nodejs.devworkspacetemplate.yaml
+++ b/samples/nodejs.devworkspacetemplate.yaml
@@ -1,5 +1,5 @@
 kind: "DevWorkspaceTemplate"
-apiVersion: "devfile.io/v1alpha1"
+apiVersion: "workspace.devfile.io/v1alpha1"
 metadata:
   name: "nodejs-stack"
 spec:


### PR DESCRIPTION
### What does this PR do?

This PR switches the Go K8S APIs back to the `workspace.devfile.io` apiGroup

### What issues does this PR fix or reference?

No issue, but a final decision to use a prefix in addition to `devfile.io`
