### PR TITLE
Dedicated pod: implement issue #48

### DIFF
--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -370,6 +370,12 @@ spec:
                             items:
                               type: string
                             type: array
+                          dedicatedPod:
+                            description: "Specify if a container should run in its
+                              own separated pod, instead of running as part of the
+                              main development environment pod. \n Default value is
+                              `false`"
+                            type: boolean
                           endpoints:
                             items:
                               properties:
@@ -886,6 +892,12 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                    dedicatedPod:
+                                      description: "Specify if a container should
+                                        run in its own separated pod, instead of running
+                                        as part of the main development environment
+                                        pod. \n Default value is `false`"
+                                      type: boolean
                                     endpoints:
                                       items:
                                         properties:
@@ -1477,6 +1489,12 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              dedicatedPod:
+                                description: "Specify if a container should run in
+                                  its own separated pod, instead of running as part
+                                  of the main development environment pod. \n Default
+                                  value is `false`"
+                                type: boolean
                               endpoints:
                                 items:
                                   properties:
@@ -2005,6 +2023,12 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                        dedicatedPod:
+                                          description: "Specify if a container should
+                                            run in its own separated pod, instead
+                                            of running as part of the main development
+                                            environment pod. \n Default value is `false`"
+                                          type: boolean
                                         endpoints:
                                           items:
                                             properties:

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -345,6 +345,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      dedicatedPod:
+                        description: "Specify if a container should run in its own
+                          separated pod, instead of running as part of the main development
+                          environment pod. \n Default value is `false`"
+                        type: boolean
                       endpoints:
                         items:
                           properties:
@@ -858,6 +863,12 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                dedicatedPod:
+                                  description: "Specify if a container should run
+                                    in its own separated pod, instead of running as
+                                    part of the main development environment pod.
+                                    \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
@@ -1425,6 +1436,12 @@ spec:
                             items:
                               type: string
                             type: array
+                          dedicatedPod:
+                            description: "Specify if a container should run in its
+                              own separated pod, instead of running as part of the
+                              main development environment pod. \n Default value is
+                              `false`"
+                            type: boolean
                           endpoints:
                             items:
                               properties:
@@ -1941,6 +1958,12 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                    dedicatedPod:
+                                      description: "Specify if a container should
+                                        run in its own separated pod, instead of running
+                                        as part of the main development environment
+                                        pod. \n Default value is `false`"
+                                      type: boolean
                                     endpoints:
                                       items:
                                         properties:

--- a/pkg/apis/workspaces/v1alpha1/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha1/containerComponent.go
@@ -59,28 +59,34 @@ type Container struct {
 	// List of volumes mounts that should be mounted is this container.
 	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty"`
 
-	//+optional
+	// +optional
 	MemoryLimit string `json:"memoryLimit,omitempty"`
 
 	// The command to run in the dockerimage component instead of the default one provided in the image.
 	// Defaults to an empty array, meaning use whatever is defined in the image.
-	//+optional
+	// +optional
 	Command []string `json:"command,omitempty"`
 
 	// The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.
 	// Defaults to an empty array, meaning use whatever is defined in the image.
-	//+optional
+	// +optional
 	Args []string `json:"args,omitempty"`
 
-	//+optional
+	// +optional
 	MountSources bool `json:"mountSources"`
 
-	//+optional
-	//
 	// Optional specification of the path in the container where
 	// project sources should be transferred/mounted when `mountSources` is `true`.
 	// When omitted, the value of the `PROJECTS_ROOT` environment variable is used.
+	// +optional
 	SourceMapping string `json:"sourceMapping"`
+
+	// Specify if a container should run in its own separated pod,
+	// instead of running as part of the main development environment pod.
+	//
+	// Default value is `false`
+	// +optional
+	DedicatedPod bool `json:"dedicatedPod"`
 }
 
 type EnvVar struct {

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -326,6 +326,10 @@
                 },
                 "type": "array"
               },
+              "dedicatedPod": {
+                "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                "type": "boolean"
+              },
               "endpoints": {
                 "items": {
                   "properties": {
@@ -848,6 +852,10 @@
                             "type": "string"
                           },
                           "type": "array"
+                        },
+                        "dedicatedPod": {
+                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                          "type": "boolean"
                         },
                         "endpoints": {
                           "items": {
@@ -1554,6 +1562,10 @@
                     },
                     "type": "array"
                   },
+                  "dedicatedPod": {
+                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                    "type": "boolean"
+                  },
                   "endpoints": {
                     "items": {
                       "properties": {
@@ -2074,6 +2086,10 @@
                                 "type": "string"
                               },
                               "type": "array"
+                            },
+                            "dedicatedPod": {
+                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                              "type": "boolean"
                             },
                             "endpoints": {
                               "items": {

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -390,6 +390,10 @@
                 },
                 "type": "array"
               },
+              "dedicatedPod": {
+                "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                "type": "boolean"
+              },
               "endpoints": {
                 "items": {
                   "properties": {
@@ -1000,6 +1004,10 @@
                             "type": "string"
                           },
                           "type": "array"
+                        },
+                        "dedicatedPod": {
+                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                          "type": "boolean"
                         },
                         "endpoints": {
                           "items": {
@@ -1775,6 +1783,10 @@
                     },
                     "type": "array"
                   },
+                  "dedicatedPod": {
+                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                    "type": "boolean"
+                  },
                   "endpoints": {
                     "items": {
                       "properties": {
@@ -2383,6 +2395,10 @@
                                 "type": "string"
                               },
                               "type": "array"
+                            },
+                            "dedicatedPod": {
+                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                              "type": "boolean"
                             },
                             "endpoints": {
                               "items": {

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -405,6 +405,10 @@
                     },
                     "type": "array"
                   },
+                  "dedicatedPod": {
+                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                    "type": "boolean"
+                  },
                   "endpoints": {
                     "items": {
                       "properties": {
@@ -1015,6 +1019,10 @@
                                 "type": "string"
                               },
                               "type": "array"
+                            },
+                            "dedicatedPod": {
+                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                              "type": "boolean"
                             },
                             "endpoints": {
                               "items": {
@@ -1790,6 +1798,10 @@
                         },
                         "type": "array"
                       },
+                      "dedicatedPod": {
+                        "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                        "type": "boolean"
+                      },
                       "endpoints": {
                         "items": {
                           "properties": {
@@ -2398,6 +2410,10 @@
                                     "type": "string"
                                   },
                                   "type": "array"
+                                },
+                                "dedicatedPod": {
+                                  "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                                  "type": "boolean"
                                 },
                                 "endpoints": {
                                   "items": {

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -414,6 +414,10 @@
                         },
                         "type": "array"
                       },
+                      "dedicatedPod": {
+                        "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                        "type": "boolean"
+                      },
                       "endpoints": {
                         "items": {
                           "properties": {
@@ -1024,6 +1028,10 @@
                                     "type": "string"
                                   },
                                   "type": "array"
+                                },
+                                "dedicatedPod": {
+                                  "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                                  "type": "boolean"
                                 },
                                 "endpoints": {
                                   "items": {
@@ -1799,6 +1807,10 @@
                             },
                             "type": "array"
                           },
+                          "dedicatedPod": {
+                            "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                            "type": "boolean"
+                          },
                           "endpoints": {
                             "items": {
                               "properties": {
@@ -2407,6 +2419,10 @@
                                         "type": "string"
                                       },
                                       "type": "array"
+                                    },
+                                    "dedicatedPod": {
+                                      "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
+                                      "type": "boolean"
                                     },
                                     "endpoints": {
                                       "items": {


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

This PR adds a new boolean `dedicatedPod` field in `container` components, to enable defining "out of main pod" container components.

### What issues does this PR fix or reference?

issue #48

### Is your PR tested? Consider putting some instruction how to test your changes

Yes, on che.openshift.io
