### PR TITLE
Enable Markdown in schema descriptions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -94,6 +94,7 @@ onError() {
 }
 trap 'onError' ERR
 
+sed -i -e '/"description":/s/ \\n - /\\n- /g' -e '/"description":/s/ \\n \([^-]\)/\\n\\n\1/g' "${BASE_DIR}/schemas/devworkspace-template.json" "${BASE_DIR}/schemas/devworkspace.json"
 
 transform "devworkspace" "${BASE_DIR}/schemas/devworkspace-template.json" ""
 transform "devworkspace" "${BASE_DIR}/schemas/devworkspace.json" 's#"path" *: *"/properties/spec/#"path": "/properties/spec/properties/template/#'

--- a/schema-transformation-rules/devworkspace/addMarkdownDescription.jq
+++ b/schema-transformation-rules/devworkspace/addMarkdownDescription.jq
@@ -1,0 +1,1 @@
+walk(if type == "object" and .description then . += { markdownDescription: .description } else . end)

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -6,25 +6,28 @@
       "items": {
         "properties": {
           "apply": {
-            "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+            "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
             "properties": {
               "attributes": {
                 "additionalProperties": {
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "component": {
                 "description": "Describes component that will be applied",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Describes component that will be applied"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -34,28 +37,33 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "label": {
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               }
             },
             "required": [
               "id"
             ],
             "type": "object",
+            "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
             "additionalProperties": false
           },
           "composite": {
@@ -66,21 +74,24 @@
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commands": {
                 "description": "The commands that comprise this composite command",
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "The commands that comprise this composite command"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -90,32 +101,38 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "label": {
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "parallel": {
                 "description": "Indicates if the sub-commands should be executed concurrently",
-                "type": "boolean"
+                "type": "boolean",
+                "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
               }
             },
             "required": [
               "id"
             ],
             "type": "object",
+            "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
             "additionalProperties": false
           },
           "exec": {
@@ -126,15 +143,18 @@
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
                 "description": "The actual command-line string",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The actual command-line string"
               },
               "component": {
                 "description": "Describes component to which given action relates",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Describes component to which given action relates"
               },
               "env": {
                 "description": "Optional list of environment variables that have to be set before running the command",
@@ -154,14 +174,16 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "Optional list of environment variables that have to be set before running the command"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -171,26 +193,31 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "label": {
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Working directory where the command should be executed"
               }
             },
             "required": [
@@ -198,6 +225,7 @@
               "commandLine"
             ],
             "type": "object",
+            "markdownDescription": "CLI Command executed in an existing component container",
             "additionalProperties": false
           },
           "vscodeLaunch": {
@@ -208,14 +236,16 @@
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -225,32 +255,38 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "inlined": {
                 "description": "Inlined content of the VsCode configuration",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Inlined content of the VsCode configuration"
               },
               "uri": {
                 "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
               }
             },
             "required": [
               "id"
             ],
             "type": "object",
+            "markdownDescription": "Command providing the definition of a VsCode launch action",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -273,14 +309,16 @@
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -290,32 +328,38 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "inlined": {
                 "description": "Inlined content of the VsCode configuration",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Inlined content of the VsCode configuration"
               },
               "uri": {
                 "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
               }
             },
             "required": [
               "id"
             ],
             "type": "object",
+            "markdownDescription": "Command providing the definition of a VsCode Task",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -361,7 +405,8 @@
           }
         ]
       },
-      "type": "array"
+      "type": "array",
+      "markdownDescription": "Predefined, ready-to-use, workspace-related commands"
     },
     "components": {
       "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
@@ -371,22 +416,25 @@
             "description": "Allows adding and configuring workspace-related containers",
             "properties": {
               "args": {
-                "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
               },
               "command": {
-                "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
               },
               "dedicatedPod": {
-                "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                "type": "boolean"
+                "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                "type": "boolean",
+                "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
               },
               "endpoints": {
                 "items": {
@@ -395,32 +443,37 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                      "type": "object"
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                     },
                     "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                       "enum": [
                         "public",
                         "internal",
                         "none"
                       ],
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
                       "type": "string"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Path of the endpoint URL"
                     },
                     "protocol": {
-                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                      "type": "string"
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                      "type": "string",
+                      "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                     },
                     "secure": {
                       "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                      "type": "boolean"
+                      "type": "boolean",
+                      "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                     },
                     "targetPort": {
                       "type": "integer"
@@ -453,7 +506,8 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "Environment variables used in this container"
               },
               "image": {
                 "type": "string"
@@ -469,7 +523,8 @@
               },
               "sourceMapping": {
                 "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
               },
               "volumeMounts": {
                 "description": "List of volumes mounts that should be mounted is this container.",
@@ -478,20 +533,24 @@
                   "properties": {
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                     }
                   },
                   "required": [
                     "name"
                   ],
                   "type": "object",
+                  "markdownDescription": "Volume that should be mounted to a component container",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "List of volumes mounts that should be mounted is this container."
               }
             },
             "required": [
@@ -499,6 +558,7 @@
               "image"
             ],
             "type": "object",
+            "markdownDescription": "Allows adding and configuring workspace-related containers",
             "additionalProperties": false
           },
           "kubernetes": {
@@ -511,32 +571,37 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                      "type": "object"
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                     },
                     "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                       "enum": [
                         "public",
                         "internal",
                         "none"
                       ],
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
                       "type": "string"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Path of the endpoint URL"
                     },
                     "protocol": {
-                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                      "type": "string"
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                      "type": "string",
+                      "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                     },
                     "secure": {
                       "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                      "type": "boolean"
+                      "type": "boolean",
+                      "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                     },
                     "targetPort": {
                       "type": "integer"
@@ -552,21 +617,25 @@
               },
               "inlined": {
                 "description": "Inlined manifest",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Inlined manifest"
               },
               "name": {
                 "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
               },
               "uri": {
                 "description": "Location in a file fetched from a uri.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Location in a file fetched from a uri."
               }
             },
             "required": [
               "name"
             ],
             "type": "object",
+            "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -591,32 +660,37 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                      "type": "object"
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                     },
                     "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                       "enum": [
                         "public",
                         "internal",
                         "none"
                       ],
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
                       "type": "string"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Path of the endpoint URL"
                     },
                     "protocol": {
-                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                      "type": "string"
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                      "type": "string",
+                      "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                     },
                     "secure": {
                       "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                      "type": "boolean"
+                      "type": "boolean",
+                      "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                     },
                     "targetPort": {
                       "type": "integer"
@@ -632,21 +706,25 @@
               },
               "inlined": {
                 "description": "Inlined manifest",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Inlined manifest"
               },
               "name": {
                 "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
               },
               "uri": {
                 "description": "Location in a file fetched from a uri.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Location in a file fetched from a uri."
               }
             },
             "required": [
               "name"
             ],
             "type": "object",
+            "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -662,32 +740,35 @@
             ]
           },
           "plugin": {
-            "description": "Allows importing a plugin. \n Plugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+            "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
             "properties": {
               "commands": {
                 "description": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge",
                 "items": {
                   "properties": {
                     "apply": {
-                      "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                      "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                       "properties": {
                         "attributes": {
                           "additionalProperties": {
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "component": {
                           "description": "Describes component that will be applied",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes component that will be applied"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -697,28 +778,33 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "label": {
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                       "additionalProperties": false
                     },
                     "composite": {
@@ -729,21 +815,24 @@
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commands": {
                           "description": "The commands that comprise this composite command",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "The commands that comprise this composite command"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -753,32 +842,38 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "label": {
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "parallel": {
                           "description": "Indicates if the sub-commands should be executed concurrently",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                       "additionalProperties": false
                     },
                     "exec": {
@@ -789,15 +884,18 @@
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
                           "description": "The actual command-line string",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "The actual command-line string"
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes component to which given action relates"
                         },
                         "env": {
                           "description": "Optional list of environment variables that have to be set before running the command",
@@ -817,14 +915,16 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -834,32 +934,38 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "label": {
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Working directory where the command should be executed"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "CLI Command executed in an existing component container",
                       "additionalProperties": false
                     },
                     "vscodeLaunch": {
@@ -870,14 +976,16 @@
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -887,32 +995,38 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "inlined": {
                           "description": "Inlined content of the VsCode configuration",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Inlined content of the VsCode configuration"
                         },
                         "uri": {
                           "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "Command providing the definition of a VsCode launch action",
                       "additionalProperties": false,
                       "oneOf": [
                         {
@@ -935,14 +1049,16 @@
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -952,32 +1068,38 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "inlined": {
                           "description": "Inlined content of the VsCode configuration",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Inlined content of the VsCode configuration"
                         },
                         "uri": {
                           "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "Command providing the definition of a VsCode Task",
                       "additionalProperties": false,
                       "oneOf": [
                         {
@@ -1023,7 +1145,8 @@
                     }
                   ]
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge"
               },
               "components": {
                 "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge",
@@ -1033,22 +1156,25 @@
                       "description": "Configuration overriding for a Container component",
                       "properties": {
                         "args": {
-                          "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                          "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                         },
                         "command": {
-                          "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                          "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                         },
                         "dedicatedPod": {
-                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                          "type": "boolean"
+                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                          "type": "boolean",
+                          "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                         },
                         "endpoints": {
                           "items": {
@@ -1057,32 +1183,37 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object"
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                               },
                               "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                 "enum": [
                                   "public",
                                   "internal",
                                   "none"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
                                 "type": "string"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Path of the endpoint URL"
                               },
                               "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                "type": "string"
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                "type": "string",
+                                "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                               },
                               "secure": {
                                 "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                               },
                               "targetPort": {
                                 "type": "integer"
@@ -1114,7 +1245,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "Environment variables used in this container"
                         },
                         "image": {
                           "type": "string"
@@ -1130,7 +1262,8 @@
                         },
                         "sourceMapping": {
                           "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                         },
                         "volumeMounts": {
                           "description": "List of volumes mounts that should be mounted is this container.",
@@ -1139,26 +1272,31 @@
                             "properties": {
                               "name": {
                                 "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                               }
                             },
                             "required": [
                               "name"
                             ],
                             "type": "object",
+                            "markdownDescription": "Volume that should be mounted to a component container",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "List of volumes mounts that should be mounted is this container."
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Configuration overriding for a Container component",
                       "additionalProperties": false
                     },
                     "kubernetes": {
@@ -1171,32 +1309,37 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object"
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                               },
                               "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                 "enum": [
                                   "public",
                                   "internal",
                                   "none"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
                                 "type": "string"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Path of the endpoint URL"
                               },
                               "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                "type": "string"
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                "type": "string",
+                                "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                               },
                               "secure": {
                                 "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                               },
                               "targetPort": {
                                 "type": "integer"
@@ -1212,21 +1355,25 @@
                         },
                         "inlined": {
                           "description": "Inlined manifest",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Inlined manifest"
                         },
                         "name": {
                           "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                         },
                         "uri": {
                           "description": "Location in a file fetched from a uri.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Location in a file fetched from a uri."
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Configuration overriding for a Kubernetes component",
                       "additionalProperties": false,
                       "oneOf": [
                         {
@@ -1251,32 +1398,37 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object"
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                               },
                               "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                 "enum": [
                                   "public",
                                   "internal",
                                   "none"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
                                 "type": "string"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Path of the endpoint URL"
                               },
                               "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                "type": "string"
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                "type": "string",
+                                "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                               },
                               "secure": {
                                 "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                               },
                               "targetPort": {
                                 "type": "integer"
@@ -1292,21 +1444,25 @@
                         },
                         "inlined": {
                           "description": "Inlined manifest",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Inlined manifest"
                         },
                         "name": {
                           "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                         },
                         "uri": {
                           "description": "Location in a file fetched from a uri.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Location in a file fetched from a uri."
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Configuration overriding for an OpenShift component",
                       "additionalProperties": false,
                       "oneOf": [
                         {
@@ -1326,17 +1482,20 @@
                       "properties": {
                         "name": {
                           "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                         },
                         "size": {
                           "description": "Size of the volume",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Size of the volume"
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Configuration overriding for a Volume component",
                       "additionalProperties": false
                     }
                   },
@@ -1365,11 +1524,13 @@
                     }
                   ]
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge"
               },
               "id": {
                 "description": "Id in a registry that contains a Devfile yaml file",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Id in a registry that contains a Devfile yaml file"
               },
               "kubernetes": {
                 "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -1385,21 +1546,25 @@
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                 "additionalProperties": false
               },
               "name": {
                 "description": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)"
               },
               "registryUrl": {
                 "type": "string"
               },
               "uri": {
                 "description": "Uri of a Devfile yaml file",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Uri of a Devfile yaml file"
               }
             },
             "type": "object",
+            "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -1424,17 +1589,20 @@
             "properties": {
               "name": {
                 "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
               },
               "size": {
                 "description": "Size of the volume",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Size of the volume"
               }
             },
             "required": [
               "name"
             ],
             "type": "object",
+            "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
             "additionalProperties": false
           }
         },
@@ -1468,7 +1636,8 @@
           }
         ]
       },
-      "type": "array"
+      "type": "array",
+      "markdownDescription": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components"
     },
     "events": {
       "description": "Bindings of commands to events. Each command is referred-to by its name.",
@@ -1478,31 +1647,36 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser."
         },
         "postStop": {
           "description": "Names of commands that should be executed after stopping the workspace.",
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Names of commands that should be executed after stopping the workspace."
         },
         "preStart": {
           "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD."
         },
         "preStop": {
           "description": "Names of commands that should be executed before stopping the workspace.",
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Names of commands that should be executed before stopping the workspace."
         }
       },
       "type": "object",
+      "markdownDescription": "Bindings of commands to events. Each command is referred-to by its name.",
       "additionalProperties": false
     },
     "parent": {
@@ -1513,25 +1687,28 @@
           "items": {
             "properties": {
               "apply": {
-                "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                 "properties": {
                   "attributes": {
                     "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "component": {
                     "description": "Describes component that will be applied",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Describes component that will be applied"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1541,28 +1718,33 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                 "additionalProperties": false
               },
               "composite": {
@@ -1573,21 +1755,24 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commands": {
                     "description": "The commands that comprise this composite command",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "The commands that comprise this composite command"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1597,32 +1782,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "parallel": {
                     "description": "Indicates if the sub-commands should be executed concurrently",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                 "additionalProperties": false
               },
               "exec": {
@@ -1633,15 +1824,18 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
                     "description": "The actual command-line string",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The actual command-line string"
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Describes component to which given action relates"
                   },
                   "env": {
                     "description": "Optional list of environment variables that have to be set before running the command",
@@ -1661,14 +1855,16 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1678,32 +1874,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Working directory where the command should be executed"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "CLI Command executed in an existing component container",
                 "additionalProperties": false
               },
               "vscodeLaunch": {
@@ -1714,14 +1916,16 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1731,32 +1935,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "inlined": {
                     "description": "Inlined content of the VsCode configuration",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined content of the VsCode configuration"
                   },
                   "uri": {
                     "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Command providing the definition of a VsCode launch action",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -1779,14 +1989,16 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1796,32 +2008,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "inlined": {
                     "description": "Inlined content of the VsCode configuration",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined content of the VsCode configuration"
                   },
                   "uri": {
                     "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Command providing the definition of a VsCode Task",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -1867,7 +2085,8 @@
               }
             ]
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Predefined, ready-to-use, workspace-related commands"
         },
         "components": {
           "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
@@ -1877,22 +2096,25 @@
                 "description": "Allows adding and configuring workspace-related containers",
                 "properties": {
                   "args": {
-                    "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                    "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                   },
                   "command": {
-                    "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                    "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                   },
                   "dedicatedPod": {
-                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                    "type": "boolean"
+                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                    "type": "boolean",
+                    "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                   },
                   "endpoints": {
                     "items": {
@@ -1901,32 +2123,37 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object"
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                           "enum": [
                             "public",
                             "internal",
                             "none"
                           ],
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
                           "type": "string"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Path of the endpoint URL"
                         },
                         "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                          "type": "string"
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                         },
                         "secure": {
                           "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                         },
                         "targetPort": {
                           "type": "integer"
@@ -1958,7 +2185,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Environment variables used in this container"
                   },
                   "image": {
                     "type": "string"
@@ -1974,7 +2202,8 @@
                   },
                   "sourceMapping": {
                     "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                   },
                   "volumeMounts": {
                     "description": "List of volumes mounts that should be mounted is this container.",
@@ -1983,26 +2212,31 @@
                       "properties": {
                         "name": {
                           "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Volume that should be mounted to a component container",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "List of volumes mounts that should be mounted is this container."
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows adding and configuring workspace-related containers",
                 "additionalProperties": false
               },
               "kubernetes": {
@@ -2015,32 +2249,37 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object"
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                           "enum": [
                             "public",
                             "internal",
                             "none"
                           ],
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
                           "type": "string"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Path of the endpoint URL"
                         },
                         "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                          "type": "string"
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                         },
                         "secure": {
                           "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                         },
                         "targetPort": {
                           "type": "integer"
@@ -2056,21 +2295,25 @@
                   },
                   "inlined": {
                     "description": "Inlined manifest",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined manifest"
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                   },
                   "uri": {
                     "description": "Location in a file fetched from a uri.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location in a file fetched from a uri."
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -2095,32 +2338,37 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object"
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                           "enum": [
                             "public",
                             "internal",
                             "none"
                           ],
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
                           "type": "string"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Path of the endpoint URL"
                         },
                         "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                          "type": "string"
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                         },
                         "secure": {
                           "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                         },
                         "targetPort": {
                           "type": "integer"
@@ -2136,21 +2384,25 @@
                   },
                   "inlined": {
                     "description": "Inlined manifest",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined manifest"
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                   },
                   "uri": {
                     "description": "Location in a file fetched from a uri.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location in a file fetched from a uri."
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -2166,32 +2418,35 @@
                 ]
               },
               "plugin": {
-                "description": "Allows importing a plugin. \n Plugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+                "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                 "properties": {
                   "commands": {
                     "description": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge",
                     "items": {
                       "properties": {
                         "apply": {
-                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                           "properties": {
                             "attributes": {
                               "additionalProperties": {
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "component": {
                               "description": "Describes component that will be applied",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes component that will be applied"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2201,28 +2456,33 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                           "additionalProperties": false
                         },
                         "composite": {
@@ -2233,21 +2493,24 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commands": {
                               "description": "The commands that comprise this composite command",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "The commands that comprise this composite command"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2257,32 +2520,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "parallel": {
                               "description": "Indicates if the sub-commands should be executed concurrently",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                           "additionalProperties": false
                         },
                         "exec": {
@@ -2293,15 +2562,18 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
                               "description": "The actual command-line string",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "The actual command-line string"
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes component to which given action relates"
                             },
                             "env": {
                               "description": "Optional list of environment variables that have to be set before running the command",
@@ -2321,14 +2593,16 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2338,32 +2612,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Working directory where the command should be executed"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "CLI Command executed in an existing component container",
                           "additionalProperties": false
                         },
                         "vscodeLaunch": {
@@ -2374,14 +2654,16 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2391,32 +2673,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "inlined": {
                               "description": "Inlined content of the VsCode configuration",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined content of the VsCode configuration"
                             },
                             "uri": {
                               "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Command providing the definition of a VsCode launch action",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -2439,14 +2727,16 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2456,32 +2746,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "inlined": {
                               "description": "Inlined content of the VsCode configuration",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined content of the VsCode configuration"
                             },
                             "uri": {
                               "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Command providing the definition of a VsCode Task",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -2527,7 +2823,8 @@
                         }
                       ]
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge"
                   },
                   "components": {
                     "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge",
@@ -2537,22 +2834,25 @@
                           "description": "Configuration overriding for a Container component",
                           "properties": {
                             "args": {
-                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                             },
                             "command": {
-                              "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                              "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                             },
                             "dedicatedPod": {
-                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                              "type": "boolean"
+                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                              "type": "boolean",
+                              "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                             },
                             "endpoints": {
                               "items": {
@@ -2561,32 +2861,37 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
-                                    "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object"
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                   },
                                   "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                     "enum": [
                                       "public",
                                       "internal",
                                       "none"
                                     ],
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
                                     "type": "string"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Path of the endpoint URL"
                                   },
                                   "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                    "type": "string"
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                   },
                                   "secure": {
                                     "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean"
+                                    "type": "boolean",
+                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                   },
                                   "targetPort": {
                                     "type": "integer"
@@ -2618,7 +2923,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "Environment variables used in this container"
                             },
                             "image": {
                               "type": "string"
@@ -2634,7 +2940,8 @@
                             },
                             "sourceMapping": {
                               "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                             },
                             "volumeMounts": {
                               "description": "List of volumes mounts that should be mounted is this container.",
@@ -2643,26 +2950,31 @@
                                 "properties": {
                                   "name": {
                                     "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                                   }
                                 },
                                 "required": [
                                   "name"
                                 ],
                                 "type": "object",
+                                "markdownDescription": "Volume that should be mounted to a component container",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "List of volumes mounts that should be mounted is this container."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for a Container component",
                           "additionalProperties": false
                         },
                         "kubernetes": {
@@ -2675,32 +2987,37 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
-                                    "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object"
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                   },
                                   "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                     "enum": [
                                       "public",
                                       "internal",
                                       "none"
                                     ],
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
                                     "type": "string"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Path of the endpoint URL"
                                   },
                                   "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                    "type": "string"
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                   },
                                   "secure": {
                                     "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean"
+                                    "type": "boolean",
+                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                   },
                                   "targetPort": {
                                     "type": "integer"
@@ -2716,21 +3033,25 @@
                             },
                             "inlined": {
                               "description": "Inlined manifest",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined manifest"
                             },
                             "name": {
                               "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                             },
                             "uri": {
                               "description": "Location in a file fetched from a uri.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location in a file fetched from a uri."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for a Kubernetes component",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -2755,32 +3076,37 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
-                                    "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object"
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                   },
                                   "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                     "enum": [
                                       "public",
                                       "internal",
                                       "none"
                                     ],
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
                                     "type": "string"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Path of the endpoint URL"
                                   },
                                   "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                    "type": "string"
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                   },
                                   "secure": {
                                     "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean"
+                                    "type": "boolean",
+                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                   },
                                   "targetPort": {
                                     "type": "integer"
@@ -2796,21 +3122,25 @@
                             },
                             "inlined": {
                               "description": "Inlined manifest",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined manifest"
                             },
                             "name": {
                               "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                             },
                             "uri": {
                               "description": "Location in a file fetched from a uri.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location in a file fetched from a uri."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for an OpenShift component",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -2830,17 +3160,20 @@
                           "properties": {
                             "name": {
                               "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                             },
                             "size": {
                               "description": "Size of the volume",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Size of the volume"
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for a Volume component",
                           "additionalProperties": false
                         }
                       },
@@ -2869,11 +3202,13 @@
                         }
                       ]
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge"
                   },
                   "id": {
                     "description": "Id in a registry that contains a Devfile yaml file",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Id in a registry that contains a Devfile yaml file"
                   },
                   "kubernetes": {
                     "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -2889,21 +3224,25 @@
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                     "additionalProperties": false
                   },
                   "name": {
                     "description": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)"
                   },
                   "registryUrl": {
                     "type": "string"
                   },
                   "uri": {
                     "description": "Uri of a Devfile yaml file",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Uri of a Devfile yaml file"
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -2928,17 +3267,20 @@
                 "properties": {
                   "name": {
                     "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                   },
                   "size": {
                     "description": "Size of the volume",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Size of the volume"
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
                 "additionalProperties": false
               }
             },
@@ -2972,7 +3314,8 @@
               }
             ]
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components"
         },
         "events": {
           "description": "Bindings of commands to events. Each command is referred-to by its name.",
@@ -2982,36 +3325,42 @@
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser."
             },
             "postStop": {
               "description": "Names of commands that should be executed after stopping the workspace.",
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed after stopping the workspace."
             },
             "preStart": {
               "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD."
             },
             "preStop": {
               "description": "Names of commands that should be executed before stopping the workspace.",
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed before stopping the workspace."
             }
           },
           "type": "object",
+          "markdownDescription": "Bindings of commands to events. Each command is referred-to by its name.",
           "additionalProperties": false
         },
         "id": {
           "description": "Id in a registry that contains a Devfile yaml file",
-          "type": "string"
+          "type": "string",
+          "markdownDescription": "Id in a registry that contains a Devfile yaml file"
         },
         "kubernetes": {
           "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -3027,6 +3376,7 @@
             "name"
           ],
           "type": "object",
+          "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
           "additionalProperties": false
         },
         "projects": {
@@ -3035,29 +3385,35 @@
             "properties": {
               "clonePath": {
                 "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
               },
               "git": {
                 "description": "Project's Git source",
                 "properties": {
                   "branch": {
                     "description": "The branch to check",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The branch to check"
                   },
                   "location": {
                     "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                   },
                   "sparseCheckoutDir": {
                     "description": "Part of project to populate in the working directory.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Part of project to populate in the working directory."
                   },
                   "startPoint": {
                     "description": "The tag or commit id to reset the checked out branch to",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The tag or commit id to reset the checked out branch to"
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Project's Git source",
                 "additionalProperties": false
               },
               "github": {
@@ -3065,41 +3421,50 @@
                 "properties": {
                   "branch": {
                     "description": "The branch to check",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The branch to check"
                   },
                   "location": {
                     "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                   },
                   "sparseCheckoutDir": {
                     "description": "Part of project to populate in the working directory.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Part of project to populate in the working directory."
                   },
                   "startPoint": {
                     "description": "The tag or commit id to reset the checked out branch to",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The tag or commit id to reset the checked out branch to"
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Project's GitHub source",
                 "additionalProperties": false
               },
               "name": {
                 "description": "Project name",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Project name"
               },
               "zip": {
                 "description": "Project's Zip source",
                 "properties": {
                   "location": {
                     "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                   },
                   "sparseCheckoutDir": {
                     "description": "Part of project to populate in the working directory.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Part of project to populate in the working directory."
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Project's Zip source",
                 "additionalProperties": false
               }
             },
@@ -3126,17 +3491,20 @@
               }
             ]
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Projects worked on in the workspace, containing names and sources locations"
         },
         "registryUrl": {
           "type": "string"
         },
         "uri": {
           "description": "Uri of a Devfile yaml file",
-          "type": "string"
+          "type": "string",
+          "markdownDescription": "Uri of a Devfile yaml file"
         }
       },
       "type": "object",
+      "markdownDescription": "Parent workspace template",
       "additionalProperties": false,
       "oneOf": [
         {
@@ -3162,29 +3530,35 @@
         "properties": {
           "clonePath": {
             "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-            "type": "string"
+            "type": "string",
+            "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
           },
           "git": {
             "description": "Project's Git source",
             "properties": {
               "branch": {
                 "description": "The branch to check",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The branch to check"
               },
               "location": {
                 "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
               },
               "sparseCheckoutDir": {
                 "description": "Part of project to populate in the working directory.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Part of project to populate in the working directory."
               },
               "startPoint": {
                 "description": "The tag or commit id to reset the checked out branch to",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The tag or commit id to reset the checked out branch to"
               }
             },
             "type": "object",
+            "markdownDescription": "Project's Git source",
             "additionalProperties": false
           },
           "github": {
@@ -3192,41 +3566,50 @@
             "properties": {
               "branch": {
                 "description": "The branch to check",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The branch to check"
               },
               "location": {
                 "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
               },
               "sparseCheckoutDir": {
                 "description": "Part of project to populate in the working directory.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Part of project to populate in the working directory."
               },
               "startPoint": {
                 "description": "The tag or commit id to reset the checked out branch to",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The tag or commit id to reset the checked out branch to"
               }
             },
             "type": "object",
+            "markdownDescription": "Project's GitHub source",
             "additionalProperties": false
           },
           "name": {
             "description": "Project name",
-            "type": "string"
+            "type": "string",
+            "markdownDescription": "Project name"
           },
           "zip": {
             "description": "Project's Zip source",
             "properties": {
               "location": {
                 "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
               },
               "sparseCheckoutDir": {
                 "description": "Part of project to populate in the working directory.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Part of project to populate in the working directory."
               }
             },
             "type": "object",
+            "markdownDescription": "Project's Zip source",
             "additionalProperties": false
           }
         },
@@ -3253,7 +3636,8 @@
           }
         ]
       },
-      "type": "array"
+      "type": "array",
+      "markdownDescription": "Projects worked on in the workspace, containing names and sources locations"
     },
     "metadata": {
       "type": "object",
@@ -3277,6 +3661,7 @@
     }
   },
   "type": "object",
+  "markdownDescription": "Structure of the workspace. This is also the specification of a workspace template.",
   "additionalProperties": false,
   "required": [
     "schemaVersion"

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -6,25 +6,28 @@
       "items": {
         "properties": {
           "apply": {
-            "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+            "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
             "properties": {
               "attributes": {
                 "additionalProperties": {
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "component": {
                 "description": "Describes component that will be applied",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Describes component that will be applied"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -34,28 +37,33 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "label": {
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               }
             },
             "required": [
               "id"
             ],
             "type": "object",
+            "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
             "additionalProperties": false
           },
           "composite": {
@@ -66,21 +74,24 @@
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commands": {
                 "description": "The commands that comprise this composite command",
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "The commands that comprise this composite command"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -90,32 +101,38 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "label": {
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "parallel": {
                 "description": "Indicates if the sub-commands should be executed concurrently",
-                "type": "boolean"
+                "type": "boolean",
+                "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
               }
             },
             "required": [
               "id"
             ],
             "type": "object",
+            "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
             "additionalProperties": false
           },
           "custom": {
@@ -126,22 +143,26 @@
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandClass": {
                 "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
               },
               "embeddedResource": {
                 "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -151,22 +172,26 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "label": {
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               }
             },
             "required": [
@@ -175,6 +200,7 @@
               "id"
             ],
             "type": "object",
+            "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
             "additionalProperties": false
           },
           "exec": {
@@ -185,15 +211,18 @@
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
                 "description": "The actual command-line string",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The actual command-line string"
               },
               "component": {
                 "description": "Describes component to which given action relates",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Describes component to which given action relates"
               },
               "env": {
                 "description": "Optional list of environment variables that have to be set before running the command",
@@ -213,14 +242,16 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "Optional list of environment variables that have to be set before running the command"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -230,26 +261,31 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "label": {
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Working directory where the command should be executed"
               }
             },
             "required": [
@@ -257,6 +293,7 @@
               "commandLine"
             ],
             "type": "object",
+            "markdownDescription": "CLI Command executed in an existing component container",
             "additionalProperties": false
           },
           "vscodeLaunch": {
@@ -267,14 +304,16 @@
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -284,32 +323,38 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "inlined": {
                 "description": "Inlined content of the VsCode configuration",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Inlined content of the VsCode configuration"
               },
               "uri": {
                 "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
               }
             },
             "required": [
               "id"
             ],
             "type": "object",
+            "markdownDescription": "Command providing the definition of a VsCode launch action",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -332,14 +377,16 @@
                   "type": "string"
                 },
                 "description": "Optional map of free-form additional command attributes",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "group": {
                 "description": "Defines the group this command is part of",
                 "properties": {
                   "isDefault": {
                     "description": "Identifies the default command for a given group kind",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Identifies the default command for a given group kind"
                   },
                   "kind": {
                     "description": "Kind of group the command is part of",
@@ -349,32 +396,38 @@
                       "test",
                       "debug"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Kind of group the command is part of"
                   }
                 },
                 "required": [
                   "kind"
                 ],
                 "type": "object",
+                "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "inlined": {
                 "description": "Inlined content of the VsCode configuration",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Inlined content of the VsCode configuration"
               },
               "uri": {
                 "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
               }
             },
             "required": [
               "id"
             ],
             "type": "object",
+            "markdownDescription": "Command providing the definition of a VsCode Task",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -425,7 +478,8 @@
           }
         ]
       },
-      "type": "array"
+      "type": "array",
+      "markdownDescription": "Predefined, ready-to-use, workspace-related commands"
     },
     "components": {
       "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
@@ -435,22 +489,25 @@
             "description": "Allows adding and configuring workspace-related containers",
             "properties": {
               "args": {
-                "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
               },
               "command": {
-                "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
               },
               "dedicatedPod": {
-                "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                "type": "boolean"
+                "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                "type": "boolean",
+                "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
               },
               "endpoints": {
                 "items": {
@@ -459,32 +516,37 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                      "type": "object"
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                     },
                     "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                       "enum": [
                         "public",
                         "internal",
                         "none"
                       ],
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
                       "type": "string"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Path of the endpoint URL"
                     },
                     "protocol": {
-                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                      "type": "string"
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                      "type": "string",
+                      "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                     },
                     "secure": {
                       "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                      "type": "boolean"
+                      "type": "boolean",
+                      "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                     },
                     "targetPort": {
                       "type": "integer"
@@ -517,7 +579,8 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "Environment variables used in this container"
               },
               "image": {
                 "type": "string"
@@ -533,7 +596,8 @@
               },
               "sourceMapping": {
                 "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
               },
               "volumeMounts": {
                 "description": "List of volumes mounts that should be mounted is this container.",
@@ -542,20 +606,24 @@
                   "properties": {
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                     }
                   },
                   "required": [
                     "name"
                   ],
                   "type": "object",
+                  "markdownDescription": "Volume that should be mounted to a component container",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "List of volumes mounts that should be mounted is this container."
               }
             },
             "required": [
@@ -563,6 +631,7 @@
               "image"
             ],
             "type": "object",
+            "markdownDescription": "Allows adding and configuring workspace-related containers",
             "additionalProperties": false
           },
           "custom": {
@@ -570,15 +639,18 @@
             "properties": {
               "componentClass": {
                 "description": "Class of component that the associated implementation controller should use to process this command with the appropriate logic",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Class of component that the associated implementation controller should use to process this command with the appropriate logic"
               },
               "embeddedResource": {
                 "description": "Additional free-form configuration for this custom component that the implementation controller will know how to use",
-                "type": "object"
+                "type": "object",
+                "markdownDescription": "Additional free-form configuration for this custom component that the implementation controller will know how to use"
               },
               "name": {
                 "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
               }
             },
             "required": [
@@ -587,6 +659,7 @@
               "name"
             ],
             "type": "object",
+            "markdownDescription": "Custom component whose logic is implementation-dependant and should be provided by the user possibly through some dedicated controller",
             "additionalProperties": false
           },
           "kubernetes": {
@@ -599,32 +672,37 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                      "type": "object"
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                     },
                     "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                       "enum": [
                         "public",
                         "internal",
                         "none"
                       ],
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
                       "type": "string"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Path of the endpoint URL"
                     },
                     "protocol": {
-                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                      "type": "string"
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                      "type": "string",
+                      "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                     },
                     "secure": {
                       "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                      "type": "boolean"
+                      "type": "boolean",
+                      "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                     },
                     "targetPort": {
                       "type": "integer"
@@ -640,21 +718,25 @@
               },
               "inlined": {
                 "description": "Inlined manifest",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Inlined manifest"
               },
               "name": {
                 "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
               },
               "uri": {
                 "description": "Location in a file fetched from a uri.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Location in a file fetched from a uri."
               }
             },
             "required": [
               "name"
             ],
             "type": "object",
+            "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -679,32 +761,37 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                      "type": "object"
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                     },
                     "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                       "enum": [
                         "public",
                         "internal",
                         "none"
                       ],
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
                       "type": "string"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
-                      "type": "string"
+                      "type": "string",
+                      "markdownDescription": "Path of the endpoint URL"
                     },
                     "protocol": {
-                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                      "type": "string"
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                      "type": "string",
+                      "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                     },
                     "secure": {
                       "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                      "type": "boolean"
+                      "type": "boolean",
+                      "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                     },
                     "targetPort": {
                       "type": "integer"
@@ -720,21 +807,25 @@
               },
               "inlined": {
                 "description": "Inlined manifest",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Inlined manifest"
               },
               "name": {
                 "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
               },
               "uri": {
                 "description": "Location in a file fetched from a uri.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Location in a file fetched from a uri."
               }
             },
             "required": [
               "name"
             ],
             "type": "object",
+            "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -750,32 +841,35 @@
             ]
           },
           "plugin": {
-            "description": "Allows importing a plugin. \n Plugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+            "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
             "properties": {
               "commands": {
                 "description": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge",
                 "items": {
                   "properties": {
                     "apply": {
-                      "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                      "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                       "properties": {
                         "attributes": {
                           "additionalProperties": {
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "component": {
                           "description": "Describes component that will be applied",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes component that will be applied"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -785,28 +879,33 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "label": {
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                       "additionalProperties": false
                     },
                     "composite": {
@@ -817,21 +916,24 @@
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commands": {
                           "description": "The commands that comprise this composite command",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "The commands that comprise this composite command"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -841,32 +943,38 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "label": {
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "parallel": {
                           "description": "Indicates if the sub-commands should be executed concurrently",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                       "additionalProperties": false
                     },
                     "custom": {
@@ -877,22 +985,26 @@
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandClass": {
                           "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                         },
                         "embeddedResource": {
                           "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -902,22 +1014,26 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "label": {
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         }
                       },
                       "required": [
@@ -926,6 +1042,7 @@
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                       "additionalProperties": false
                     },
                     "exec": {
@@ -936,15 +1053,18 @@
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
                           "description": "The actual command-line string",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "The actual command-line string"
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes component to which given action relates"
                         },
                         "env": {
                           "description": "Optional list of environment variables that have to be set before running the command",
@@ -964,14 +1084,16 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -981,32 +1103,38 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "label": {
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Working directory where the command should be executed"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "CLI Command executed in an existing component container",
                       "additionalProperties": false
                     },
                     "vscodeLaunch": {
@@ -1017,14 +1145,16 @@
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -1034,32 +1164,38 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "inlined": {
                           "description": "Inlined content of the VsCode configuration",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Inlined content of the VsCode configuration"
                         },
                         "uri": {
                           "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "Command providing the definition of a VsCode launch action",
                       "additionalProperties": false,
                       "oneOf": [
                         {
@@ -1082,14 +1218,16 @@
                             "type": "string"
                           },
                           "description": "Optional map of free-form additional command attributes",
-                          "type": "object"
+                          "type": "object",
+                          "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "group": {
                           "description": "Defines the group this command is part of",
                           "properties": {
                             "isDefault": {
                               "description": "Identifies the default command for a given group kind",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Identifies the default command for a given group kind"
                             },
                             "kind": {
                               "description": "Kind of group the command is part of",
@@ -1099,32 +1237,38 @@
                                 "test",
                                 "debug"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Kind of group the command is part of"
                             }
                           },
                           "required": [
                             "kind"
                           ],
                           "type": "object",
+                          "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "inlined": {
                           "description": "Inlined content of the VsCode configuration",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Inlined content of the VsCode configuration"
                         },
                         "uri": {
                           "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                         }
                       },
                       "required": [
                         "id"
                       ],
                       "type": "object",
+                      "markdownDescription": "Command providing the definition of a VsCode Task",
                       "additionalProperties": false,
                       "oneOf": [
                         {
@@ -1175,7 +1319,8 @@
                     }
                   ]
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge"
               },
               "components": {
                 "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge",
@@ -1185,22 +1330,25 @@
                       "description": "Configuration overriding for a Container component",
                       "properties": {
                         "args": {
-                          "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                          "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                         },
                         "command": {
-                          "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                          "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                         },
                         "dedicatedPod": {
-                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                          "type": "boolean"
+                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                          "type": "boolean",
+                          "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                         },
                         "endpoints": {
                           "items": {
@@ -1209,32 +1357,37 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object"
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                               },
                               "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                 "enum": [
                                   "public",
                                   "internal",
                                   "none"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
                                 "type": "string"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Path of the endpoint URL"
                               },
                               "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                "type": "string"
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                "type": "string",
+                                "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                               },
                               "secure": {
                                 "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                               },
                               "targetPort": {
                                 "type": "integer"
@@ -1266,7 +1419,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "Environment variables used in this container"
                         },
                         "image": {
                           "type": "string"
@@ -1282,7 +1436,8 @@
                         },
                         "sourceMapping": {
                           "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                         },
                         "volumeMounts": {
                           "description": "List of volumes mounts that should be mounted is this container.",
@@ -1291,26 +1446,31 @@
                             "properties": {
                               "name": {
                                 "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                               }
                             },
                             "required": [
                               "name"
                             ],
                             "type": "object",
+                            "markdownDescription": "Volume that should be mounted to a component container",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "markdownDescription": "List of volumes mounts that should be mounted is this container."
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Configuration overriding for a Container component",
                       "additionalProperties": false
                     },
                     "kubernetes": {
@@ -1323,32 +1483,37 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object"
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                               },
                               "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                 "enum": [
                                   "public",
                                   "internal",
                                   "none"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
                                 "type": "string"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Path of the endpoint URL"
                               },
                               "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                "type": "string"
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                "type": "string",
+                                "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                               },
                               "secure": {
                                 "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                               },
                               "targetPort": {
                                 "type": "integer"
@@ -1364,21 +1529,25 @@
                         },
                         "inlined": {
                           "description": "Inlined manifest",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Inlined manifest"
                         },
                         "name": {
                           "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                         },
                         "uri": {
                           "description": "Location in a file fetched from a uri.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Location in a file fetched from a uri."
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Configuration overriding for a Kubernetes component",
                       "additionalProperties": false,
                       "oneOf": [
                         {
@@ -1403,32 +1572,37 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object"
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                               },
                               "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                 "enum": [
                                   "public",
                                   "internal",
                                   "none"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
                                 "type": "string"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Path of the endpoint URL"
                               },
                               "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                "type": "string"
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                "type": "string",
+                                "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                               },
                               "secure": {
                                 "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                               },
                               "targetPort": {
                                 "type": "integer"
@@ -1444,21 +1618,25 @@
                         },
                         "inlined": {
                           "description": "Inlined manifest",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Inlined manifest"
                         },
                         "name": {
                           "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                         },
                         "uri": {
                           "description": "Location in a file fetched from a uri.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Location in a file fetched from a uri."
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Configuration overriding for an OpenShift component",
                       "additionalProperties": false,
                       "oneOf": [
                         {
@@ -1478,17 +1656,20 @@
                       "properties": {
                         "name": {
                           "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                         },
                         "size": {
                           "description": "Size of the volume",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Size of the volume"
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Configuration overriding for a Volume component",
                       "additionalProperties": false
                     }
                   },
@@ -1517,11 +1698,13 @@
                     }
                   ]
                 },
-                "type": "array"
+                "type": "array",
+                "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge"
               },
               "id": {
                 "description": "Id in a registry that contains a Devfile yaml file",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Id in a registry that contains a Devfile yaml file"
               },
               "kubernetes": {
                 "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -1537,21 +1720,25 @@
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                 "additionalProperties": false
               },
               "name": {
                 "description": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)"
               },
               "registryUrl": {
                 "type": "string"
               },
               "uri": {
                 "description": "Uri of a Devfile yaml file",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Uri of a Devfile yaml file"
               }
             },
             "type": "object",
+            "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
             "additionalProperties": false,
             "oneOf": [
               {
@@ -1576,17 +1763,20 @@
             "properties": {
               "name": {
                 "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
               },
               "size": {
                 "description": "Size of the volume",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Size of the volume"
               }
             },
             "required": [
               "name"
             ],
             "type": "object",
+            "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
             "additionalProperties": false
           }
         },
@@ -1625,7 +1815,8 @@
           }
         ]
       },
-      "type": "array"
+      "type": "array",
+      "markdownDescription": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components"
     },
     "events": {
       "description": "Bindings of commands to events. Each command is referred-to by its name.",
@@ -1635,31 +1826,36 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser."
         },
         "postStop": {
           "description": "Names of commands that should be executed after stopping the workspace.",
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Names of commands that should be executed after stopping the workspace."
         },
         "preStart": {
           "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD."
         },
         "preStop": {
           "description": "Names of commands that should be executed before stopping the workspace.",
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Names of commands that should be executed before stopping the workspace."
         }
       },
       "type": "object",
+      "markdownDescription": "Bindings of commands to events. Each command is referred-to by its name.",
       "additionalProperties": false
     },
     "parent": {
@@ -1670,25 +1866,28 @@
           "items": {
             "properties": {
               "apply": {
-                "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                 "properties": {
                   "attributes": {
                     "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "component": {
                     "description": "Describes component that will be applied",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Describes component that will be applied"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1698,28 +1897,33 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                 "additionalProperties": false
               },
               "composite": {
@@ -1730,21 +1934,24 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commands": {
                     "description": "The commands that comprise this composite command",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "The commands that comprise this composite command"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1754,32 +1961,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "parallel": {
                     "description": "Indicates if the sub-commands should be executed concurrently",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                 "additionalProperties": false
               },
               "custom": {
@@ -1790,22 +2003,26 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandClass": {
                     "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                   },
                   "embeddedResource": {
                     "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1815,22 +2032,26 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   }
                 },
                 "required": [
@@ -1839,6 +2060,7 @@
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                 "additionalProperties": false
               },
               "exec": {
@@ -1849,15 +2071,18 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
                     "description": "The actual command-line string",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The actual command-line string"
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Describes component to which given action relates"
                   },
                   "env": {
                     "description": "Optional list of environment variables that have to be set before running the command",
@@ -1877,14 +2102,16 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1894,32 +2121,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Working directory where the command should be executed"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "CLI Command executed in an existing component container",
                 "additionalProperties": false
               },
               "vscodeLaunch": {
@@ -1930,14 +2163,16 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -1947,32 +2182,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "inlined": {
                     "description": "Inlined content of the VsCode configuration",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined content of the VsCode configuration"
                   },
                   "uri": {
                     "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Command providing the definition of a VsCode launch action",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -1995,14 +2236,16 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -2012,32 +2255,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "inlined": {
                     "description": "Inlined content of the VsCode configuration",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined content of the VsCode configuration"
                   },
                   "uri": {
                     "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Command providing the definition of a VsCode Task",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -2088,7 +2337,8 @@
               }
             ]
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Predefined, ready-to-use, workspace-related commands"
         },
         "components": {
           "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
@@ -2098,22 +2348,25 @@
                 "description": "Allows adding and configuring workspace-related containers",
                 "properties": {
                   "args": {
-                    "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                    "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                   },
                   "command": {
-                    "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                    "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                   },
                   "dedicatedPod": {
-                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                    "type": "boolean"
+                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                    "type": "boolean",
+                    "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                   },
                   "endpoints": {
                     "items": {
@@ -2122,32 +2375,37 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object"
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                           "enum": [
                             "public",
                             "internal",
                             "none"
                           ],
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
                           "type": "string"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Path of the endpoint URL"
                         },
                         "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                          "type": "string"
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                         },
                         "secure": {
                           "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                         },
                         "targetPort": {
                           "type": "integer"
@@ -2179,7 +2437,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Environment variables used in this container"
                   },
                   "image": {
                     "type": "string"
@@ -2195,7 +2454,8 @@
                   },
                   "sourceMapping": {
                     "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                   },
                   "volumeMounts": {
                     "description": "List of volumes mounts that should be mounted is this container.",
@@ -2204,26 +2464,31 @@
                       "properties": {
                         "name": {
                           "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Volume that should be mounted to a component container",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "List of volumes mounts that should be mounted is this container."
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows adding and configuring workspace-related containers",
                 "additionalProperties": false
               },
               "custom": {
@@ -2231,15 +2496,18 @@
                 "properties": {
                   "componentClass": {
                     "description": "Class of component that the associated implementation controller should use to process this command with the appropriate logic",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Class of component that the associated implementation controller should use to process this command with the appropriate logic"
                   },
                   "embeddedResource": {
                     "description": "Additional free-form configuration for this custom component that the implementation controller will know how to use",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Additional free-form configuration for this custom component that the implementation controller will know how to use"
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                   }
                 },
                 "required": [
@@ -2248,6 +2516,7 @@
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Custom component whose logic is implementation-dependant and should be provided by the user possibly through some dedicated controller",
                 "additionalProperties": false
               },
               "kubernetes": {
@@ -2260,32 +2529,37 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object"
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                           "enum": [
                             "public",
                             "internal",
                             "none"
                           ],
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
                           "type": "string"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Path of the endpoint URL"
                         },
                         "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                          "type": "string"
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                         },
                         "secure": {
                           "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                         },
                         "targetPort": {
                           "type": "integer"
@@ -2301,21 +2575,25 @@
                   },
                   "inlined": {
                     "description": "Inlined manifest",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined manifest"
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                   },
                   "uri": {
                     "description": "Location in a file fetched from a uri.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location in a file fetched from a uri."
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -2340,32 +2618,37 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object"
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                           "enum": [
                             "public",
                             "internal",
                             "none"
                           ],
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
                           "type": "string"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Path of the endpoint URL"
                         },
                         "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                          "type": "string"
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                         },
                         "secure": {
                           "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                         },
                         "targetPort": {
                           "type": "integer"
@@ -2381,21 +2664,25 @@
                   },
                   "inlined": {
                     "description": "Inlined manifest",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined manifest"
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                   },
                   "uri": {
                     "description": "Location in a file fetched from a uri.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location in a file fetched from a uri."
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -2411,32 +2698,35 @@
                 ]
               },
               "plugin": {
-                "description": "Allows importing a plugin. \n Plugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+                "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                 "properties": {
                   "commands": {
                     "description": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge",
                     "items": {
                       "properties": {
                         "apply": {
-                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                           "properties": {
                             "attributes": {
                               "additionalProperties": {
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "component": {
                               "description": "Describes component that will be applied",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes component that will be applied"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2446,28 +2736,33 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                           "additionalProperties": false
                         },
                         "composite": {
@@ -2478,21 +2773,24 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commands": {
                               "description": "The commands that comprise this composite command",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "The commands that comprise this composite command"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2502,32 +2800,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "parallel": {
                               "description": "Indicates if the sub-commands should be executed concurrently",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                           "additionalProperties": false
                         },
                         "custom": {
@@ -2538,22 +2842,26 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandClass": {
                               "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                             },
                             "embeddedResource": {
                               "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2563,22 +2871,26 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             }
                           },
                           "required": [
@@ -2587,6 +2899,7 @@
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                           "additionalProperties": false
                         },
                         "exec": {
@@ -2597,15 +2910,18 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
                               "description": "The actual command-line string",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "The actual command-line string"
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes component to which given action relates"
                             },
                             "env": {
                               "description": "Optional list of environment variables that have to be set before running the command",
@@ -2625,14 +2941,16 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2642,32 +2960,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Working directory where the command should be executed"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "CLI Command executed in an existing component container",
                           "additionalProperties": false
                         },
                         "vscodeLaunch": {
@@ -2678,14 +3002,16 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2695,32 +3021,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "inlined": {
                               "description": "Inlined content of the VsCode configuration",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined content of the VsCode configuration"
                             },
                             "uri": {
                               "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Command providing the definition of a VsCode launch action",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -2743,14 +3075,16 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -2760,32 +3094,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "inlined": {
                               "description": "Inlined content of the VsCode configuration",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined content of the VsCode configuration"
                             },
                             "uri": {
                               "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Command providing the definition of a VsCode Task",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -2836,7 +3176,8 @@
                         }
                       ]
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge"
                   },
                   "components": {
                     "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge",
@@ -2846,22 +3187,25 @@
                           "description": "Configuration overriding for a Container component",
                           "properties": {
                             "args": {
-                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                             },
                             "command": {
-                              "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                              "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                             },
                             "dedicatedPod": {
-                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                              "type": "boolean"
+                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                              "type": "boolean",
+                              "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                             },
                             "endpoints": {
                               "items": {
@@ -2870,32 +3214,37 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
-                                    "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object"
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                   },
                                   "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                     "enum": [
                                       "public",
                                       "internal",
                                       "none"
                                     ],
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
                                     "type": "string"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Path of the endpoint URL"
                                   },
                                   "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                    "type": "string"
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                   },
                                   "secure": {
                                     "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean"
+                                    "type": "boolean",
+                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                   },
                                   "targetPort": {
                                     "type": "integer"
@@ -2927,7 +3276,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "Environment variables used in this container"
                             },
                             "image": {
                               "type": "string"
@@ -2943,7 +3293,8 @@
                             },
                             "sourceMapping": {
                               "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                             },
                             "volumeMounts": {
                               "description": "List of volumes mounts that should be mounted is this container.",
@@ -2952,26 +3303,31 @@
                                 "properties": {
                                   "name": {
                                     "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                                   }
                                 },
                                 "required": [
                                   "name"
                                 ],
                                 "type": "object",
+                                "markdownDescription": "Volume that should be mounted to a component container",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "List of volumes mounts that should be mounted is this container."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for a Container component",
                           "additionalProperties": false
                         },
                         "kubernetes": {
@@ -2984,32 +3340,37 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
-                                    "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object"
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                   },
                                   "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                     "enum": [
                                       "public",
                                       "internal",
                                       "none"
                                     ],
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
                                     "type": "string"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Path of the endpoint URL"
                                   },
                                   "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                    "type": "string"
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                   },
                                   "secure": {
                                     "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean"
+                                    "type": "boolean",
+                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                   },
                                   "targetPort": {
                                     "type": "integer"
@@ -3025,21 +3386,25 @@
                             },
                             "inlined": {
                               "description": "Inlined manifest",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined manifest"
                             },
                             "name": {
                               "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                             },
                             "uri": {
                               "description": "Location in a file fetched from a uri.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location in a file fetched from a uri."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for a Kubernetes component",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -3064,32 +3429,37 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
-                                    "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object"
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                   },
                                   "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                     "enum": [
                                       "public",
                                       "internal",
                                       "none"
                                     ],
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
                                     "type": "string"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Path of the endpoint URL"
                                   },
                                   "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                    "type": "string"
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                   },
                                   "secure": {
                                     "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean"
+                                    "type": "boolean",
+                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                   },
                                   "targetPort": {
                                     "type": "integer"
@@ -3105,21 +3475,25 @@
                             },
                             "inlined": {
                               "description": "Inlined manifest",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined manifest"
                             },
                             "name": {
                               "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                             },
                             "uri": {
                               "description": "Location in a file fetched from a uri.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location in a file fetched from a uri."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for an OpenShift component",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -3139,17 +3513,20 @@
                           "properties": {
                             "name": {
                               "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                             },
                             "size": {
                               "description": "Size of the volume",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Size of the volume"
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for a Volume component",
                           "additionalProperties": false
                         }
                       },
@@ -3178,11 +3555,13 @@
                         }
                       ]
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge"
                   },
                   "id": {
                     "description": "Id in a registry that contains a Devfile yaml file",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Id in a registry that contains a Devfile yaml file"
                   },
                   "kubernetes": {
                     "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -3198,21 +3577,25 @@
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                     "additionalProperties": false
                   },
                   "name": {
                     "description": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)"
                   },
                   "registryUrl": {
                     "type": "string"
                   },
                   "uri": {
                     "description": "Uri of a Devfile yaml file",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Uri of a Devfile yaml file"
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -3237,17 +3620,20 @@
                 "properties": {
                   "name": {
                     "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                   },
                   "size": {
                     "description": "Size of the volume",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Size of the volume"
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
                 "additionalProperties": false
               }
             },
@@ -3286,7 +3672,8 @@
               }
             ]
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components"
         },
         "events": {
           "description": "Bindings of commands to events. Each command is referred-to by its name.",
@@ -3296,36 +3683,42 @@
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser."
             },
             "postStop": {
               "description": "Names of commands that should be executed after stopping the workspace.",
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed after stopping the workspace."
             },
             "preStart": {
               "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD."
             },
             "preStop": {
               "description": "Names of commands that should be executed before stopping the workspace.",
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed before stopping the workspace."
             }
           },
           "type": "object",
+          "markdownDescription": "Bindings of commands to events. Each command is referred-to by its name.",
           "additionalProperties": false
         },
         "id": {
           "description": "Id in a registry that contains a Devfile yaml file",
-          "type": "string"
+          "type": "string",
+          "markdownDescription": "Id in a registry that contains a Devfile yaml file"
         },
         "kubernetes": {
           "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -3341,6 +3734,7 @@
             "name"
           ],
           "type": "object",
+          "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
           "additionalProperties": false
         },
         "projects": {
@@ -3349,7 +3743,8 @@
             "properties": {
               "clonePath": {
                 "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
               },
               "custom": {
                 "description": "Project's Custom source",
@@ -3366,6 +3761,7 @@
                   "projectSourceClass"
                 ],
                 "type": "object",
+                "markdownDescription": "Project's Custom source",
                 "additionalProperties": false
               },
               "git": {
@@ -3373,22 +3769,27 @@
                 "properties": {
                   "branch": {
                     "description": "The branch to check",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The branch to check"
                   },
                   "location": {
                     "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                   },
                   "sparseCheckoutDir": {
                     "description": "Part of project to populate in the working directory.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Part of project to populate in the working directory."
                   },
                   "startPoint": {
                     "description": "The tag or commit id to reset the checked out branch to",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The tag or commit id to reset the checked out branch to"
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Project's Git source",
                 "additionalProperties": false
               },
               "github": {
@@ -3396,41 +3797,50 @@
                 "properties": {
                   "branch": {
                     "description": "The branch to check",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The branch to check"
                   },
                   "location": {
                     "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                   },
                   "sparseCheckoutDir": {
                     "description": "Part of project to populate in the working directory.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Part of project to populate in the working directory."
                   },
                   "startPoint": {
                     "description": "The tag or commit id to reset the checked out branch to",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The tag or commit id to reset the checked out branch to"
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Project's GitHub source",
                 "additionalProperties": false
               },
               "name": {
                 "description": "Project name",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Project name"
               },
               "zip": {
                 "description": "Project's Zip source",
                 "properties": {
                   "location": {
                     "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                   },
                   "sparseCheckoutDir": {
                     "description": "Part of project to populate in the working directory.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Part of project to populate in the working directory."
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Project's Zip source",
                 "additionalProperties": false
               }
             },
@@ -3462,17 +3872,20 @@
               }
             ]
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Projects worked on in the workspace, containing names and sources locations"
         },
         "registryUrl": {
           "type": "string"
         },
         "uri": {
           "description": "Uri of a Devfile yaml file",
-          "type": "string"
+          "type": "string",
+          "markdownDescription": "Uri of a Devfile yaml file"
         }
       },
       "type": "object",
+      "markdownDescription": "Parent workspace template",
       "additionalProperties": false,
       "oneOf": [
         {
@@ -3498,7 +3911,8 @@
         "properties": {
           "clonePath": {
             "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-            "type": "string"
+            "type": "string",
+            "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
           },
           "custom": {
             "description": "Project's Custom source",
@@ -3515,6 +3929,7 @@
               "projectSourceClass"
             ],
             "type": "object",
+            "markdownDescription": "Project's Custom source",
             "additionalProperties": false
           },
           "git": {
@@ -3522,22 +3937,27 @@
             "properties": {
               "branch": {
                 "description": "The branch to check",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The branch to check"
               },
               "location": {
                 "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
               },
               "sparseCheckoutDir": {
                 "description": "Part of project to populate in the working directory.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Part of project to populate in the working directory."
               },
               "startPoint": {
                 "description": "The tag or commit id to reset the checked out branch to",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The tag or commit id to reset the checked out branch to"
               }
             },
             "type": "object",
+            "markdownDescription": "Project's Git source",
             "additionalProperties": false
           },
           "github": {
@@ -3545,41 +3965,50 @@
             "properties": {
               "branch": {
                 "description": "The branch to check",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The branch to check"
               },
               "location": {
                 "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
               },
               "sparseCheckoutDir": {
                 "description": "Part of project to populate in the working directory.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Part of project to populate in the working directory."
               },
               "startPoint": {
                 "description": "The tag or commit id to reset the checked out branch to",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "The tag or commit id to reset the checked out branch to"
               }
             },
             "type": "object",
+            "markdownDescription": "Project's GitHub source",
             "additionalProperties": false
           },
           "name": {
             "description": "Project name",
-            "type": "string"
+            "type": "string",
+            "markdownDescription": "Project name"
           },
           "zip": {
             "description": "Project's Zip source",
             "properties": {
               "location": {
                 "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
               },
               "sparseCheckoutDir": {
                 "description": "Part of project to populate in the working directory.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Part of project to populate in the working directory."
               }
             },
             "type": "object",
+            "markdownDescription": "Project's Zip source",
             "additionalProperties": false
           }
         },
@@ -3611,9 +4040,11 @@
           }
         ]
       },
-      "type": "array"
+      "type": "array",
+      "markdownDescription": "Projects worked on in the workspace, containing names and sources locations"
     }
   },
   "type": "object",
+  "markdownDescription": "Structure of the workspace. This is also the specification of a workspace template.",
   "additionalProperties": false
 }

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -3,11 +3,13 @@
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
+      "type": "string",
+      "markdownDescription": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
+      "type": "string",
+      "markdownDescription": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata": {
       "type": "object",
@@ -21,25 +23,28 @@
           "items": {
             "properties": {
               "apply": {
-                "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                 "properties": {
                   "attributes": {
                     "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "component": {
                     "description": "Describes component that will be applied",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Describes component that will be applied"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -49,28 +54,33 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                 "additionalProperties": false
               },
               "composite": {
@@ -81,21 +91,24 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commands": {
                     "description": "The commands that comprise this composite command",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "The commands that comprise this composite command"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -105,32 +118,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "parallel": {
                     "description": "Indicates if the sub-commands should be executed concurrently",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                 "additionalProperties": false
               },
               "custom": {
@@ -141,22 +160,26 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandClass": {
                     "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                   },
                   "embeddedResource": {
                     "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -166,22 +189,26 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   }
                 },
                 "required": [
@@ -190,6 +217,7 @@
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                 "additionalProperties": false
               },
               "exec": {
@@ -200,15 +228,18 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
                     "description": "The actual command-line string",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The actual command-line string"
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Describes component to which given action relates"
                   },
                   "env": {
                     "description": "Optional list of environment variables that have to be set before running the command",
@@ -228,14 +259,16 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -245,26 +278,31 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "label": {
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Working directory where the command should be executed"
                   }
                 },
                 "required": [
@@ -272,6 +310,7 @@
                   "commandLine"
                 ],
                 "type": "object",
+                "markdownDescription": "CLI Command executed in an existing component container",
                 "additionalProperties": false
               },
               "vscodeLaunch": {
@@ -282,14 +321,16 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -299,32 +340,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "inlined": {
                     "description": "Inlined content of the VsCode configuration",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined content of the VsCode configuration"
                   },
                   "uri": {
                     "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Command providing the definition of a VsCode launch action",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -347,14 +394,16 @@
                       "type": "string"
                     },
                     "description": "Optional map of free-form additional command attributes",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "group": {
                     "description": "Defines the group this command is part of",
                     "properties": {
                       "isDefault": {
                         "description": "Identifies the default command for a given group kind",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Identifies the default command for a given group kind"
                       },
                       "kind": {
                         "description": "Kind of group the command is part of",
@@ -364,32 +413,38 @@
                           "test",
                           "debug"
                         ],
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Kind of group the command is part of"
                       }
                     },
                     "required": [
                       "kind"
                     ],
                     "type": "object",
+                    "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "inlined": {
                     "description": "Inlined content of the VsCode configuration",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined content of the VsCode configuration"
                   },
                   "uri": {
                     "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                   }
                 },
                 "required": [
                   "id"
                 ],
                 "type": "object",
+                "markdownDescription": "Command providing the definition of a VsCode Task",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -440,7 +495,8 @@
               }
             ]
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Predefined, ready-to-use, workspace-related commands"
         },
         "components": {
           "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
@@ -450,22 +506,25 @@
                 "description": "Allows adding and configuring workspace-related containers",
                 "properties": {
                   "args": {
-                    "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                    "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                   },
                   "command": {
-                    "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                    "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                   },
                   "dedicatedPod": {
-                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                    "type": "boolean"
+                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                    "type": "boolean",
+                    "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                   },
                   "endpoints": {
                     "items": {
@@ -474,32 +533,37 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object"
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                           "enum": [
                             "public",
                             "internal",
                             "none"
                           ],
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
                           "type": "string"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Path of the endpoint URL"
                         },
                         "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                          "type": "string"
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                         },
                         "secure": {
                           "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                         },
                         "targetPort": {
                           "type": "integer"
@@ -532,7 +596,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Environment variables used in this container"
                   },
                   "image": {
                     "type": "string"
@@ -548,7 +613,8 @@
                   },
                   "sourceMapping": {
                     "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                   },
                   "volumeMounts": {
                     "description": "List of volumes mounts that should be mounted is this container.",
@@ -557,20 +623,24 @@
                       "properties": {
                         "name": {
                           "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                         }
                       },
                       "required": [
                         "name"
                       ],
                       "type": "object",
+                      "markdownDescription": "Volume that should be mounted to a component container",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "List of volumes mounts that should be mounted is this container."
                   }
                 },
                 "required": [
@@ -578,6 +648,7 @@
                   "image"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows adding and configuring workspace-related containers",
                 "additionalProperties": false
               },
               "custom": {
@@ -585,15 +656,18 @@
                 "properties": {
                   "componentClass": {
                     "description": "Class of component that the associated implementation controller should use to process this command with the appropriate logic",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Class of component that the associated implementation controller should use to process this command with the appropriate logic"
                   },
                   "embeddedResource": {
                     "description": "Additional free-form configuration for this custom component that the implementation controller will know how to use",
-                    "type": "object"
+                    "type": "object",
+                    "markdownDescription": "Additional free-form configuration for this custom component that the implementation controller will know how to use"
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                   }
                 },
                 "required": [
@@ -602,6 +676,7 @@
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Custom component whose logic is implementation-dependant and should be provided by the user possibly through some dedicated controller",
                 "additionalProperties": false
               },
               "kubernetes": {
@@ -614,32 +689,37 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object"
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                           "enum": [
                             "public",
                             "internal",
                             "none"
                           ],
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
                           "type": "string"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Path of the endpoint URL"
                         },
                         "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                          "type": "string"
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                         },
                         "secure": {
                           "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                         },
                         "targetPort": {
                           "type": "integer"
@@ -655,21 +735,25 @@
                   },
                   "inlined": {
                     "description": "Inlined manifest",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined manifest"
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                   },
                   "uri": {
                     "description": "Location in a file fetched from a uri.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location in a file fetched from a uri."
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -694,32 +778,37 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object"
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                         },
                         "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                           "enum": [
                             "public",
                             "internal",
                             "none"
                           ],
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
                           "type": "string"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
-                          "type": "string"
+                          "type": "string",
+                          "markdownDescription": "Path of the endpoint URL"
                         },
                         "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                          "type": "string"
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                         },
                         "secure": {
                           "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                         },
                         "targetPort": {
                           "type": "integer"
@@ -735,21 +824,25 @@
                   },
                   "inlined": {
                     "description": "Inlined manifest",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Inlined manifest"
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                   },
                   "uri": {
                     "description": "Location in a file fetched from a uri.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Location in a file fetched from a uri."
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -765,32 +858,35 @@
                 ]
               },
               "plugin": {
-                "description": "Allows importing a plugin. \n Plugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+                "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                 "properties": {
                   "commands": {
                     "description": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge",
                     "items": {
                       "properties": {
                         "apply": {
-                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                           "properties": {
                             "attributes": {
                               "additionalProperties": {
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "component": {
                               "description": "Describes component that will be applied",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes component that will be applied"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -800,28 +896,33 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                           "additionalProperties": false
                         },
                         "composite": {
@@ -832,21 +933,24 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commands": {
                               "description": "The commands that comprise this composite command",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "The commands that comprise this composite command"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -856,32 +960,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "parallel": {
                               "description": "Indicates if the sub-commands should be executed concurrently",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                           "additionalProperties": false
                         },
                         "custom": {
@@ -892,22 +1002,26 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandClass": {
                               "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                             },
                             "embeddedResource": {
                               "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -917,22 +1031,26 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             }
                           },
                           "required": [
@@ -941,6 +1059,7 @@
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                           "additionalProperties": false
                         },
                         "exec": {
@@ -951,15 +1070,18 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
                               "description": "The actual command-line string",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "The actual command-line string"
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes component to which given action relates"
                             },
                             "env": {
                               "description": "Optional list of environment variables that have to be set before running the command",
@@ -979,14 +1101,16 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -996,32 +1120,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "label": {
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Working directory where the command should be executed"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "CLI Command executed in an existing component container",
                           "additionalProperties": false
                         },
                         "vscodeLaunch": {
@@ -1032,14 +1162,16 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -1049,32 +1181,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "inlined": {
                               "description": "Inlined content of the VsCode configuration",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined content of the VsCode configuration"
                             },
                             "uri": {
                               "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Command providing the definition of a VsCode launch action",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -1097,14 +1235,16 @@
                                 "type": "string"
                               },
                               "description": "Optional map of free-form additional command attributes",
-                              "type": "object"
+                              "type": "object",
+                              "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "group": {
                               "description": "Defines the group this command is part of",
                               "properties": {
                                 "isDefault": {
                                   "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Identifies the default command for a given group kind"
                                 },
                                 "kind": {
                                   "description": "Kind of group the command is part of",
@@ -1114,32 +1254,38 @@
                                     "test",
                                     "debug"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Kind of group the command is part of"
                                 }
                               },
                               "required": [
                                 "kind"
                               ],
                               "type": "object",
+                              "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "inlined": {
                               "description": "Inlined content of the VsCode configuration",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined content of the VsCode configuration"
                             },
                             "uri": {
                               "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                             }
                           },
                           "required": [
                             "id"
                           ],
                           "type": "object",
+                          "markdownDescription": "Command providing the definition of a VsCode Task",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -1190,7 +1336,8 @@
                         }
                       ]
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge"
                   },
                   "components": {
                     "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge",
@@ -1200,22 +1347,25 @@
                           "description": "Configuration overriding for a Container component",
                           "properties": {
                             "args": {
-                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                             },
                             "command": {
-                              "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                              "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                             },
                             "dedicatedPod": {
-                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                              "type": "boolean"
+                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                              "type": "boolean",
+                              "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                             },
                             "endpoints": {
                               "items": {
@@ -1224,32 +1374,37 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
-                                    "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object"
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                   },
                                   "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                     "enum": [
                                       "public",
                                       "internal",
                                       "none"
                                     ],
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
                                     "type": "string"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Path of the endpoint URL"
                                   },
                                   "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                    "type": "string"
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                   },
                                   "secure": {
                                     "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean"
+                                    "type": "boolean",
+                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                   },
                                   "targetPort": {
                                     "type": "integer"
@@ -1281,7 +1436,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "Environment variables used in this container"
                             },
                             "image": {
                               "type": "string"
@@ -1297,7 +1453,8 @@
                             },
                             "sourceMapping": {
                               "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                             },
                             "volumeMounts": {
                               "description": "List of volumes mounts that should be mounted is this container.",
@@ -1306,26 +1463,31 @@
                                 "properties": {
                                   "name": {
                                     "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                                   }
                                 },
                                 "required": [
                                   "name"
                                 ],
                                 "type": "object",
+                                "markdownDescription": "Volume that should be mounted to a component container",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "markdownDescription": "List of volumes mounts that should be mounted is this container."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for a Container component",
                           "additionalProperties": false
                         },
                         "kubernetes": {
@@ -1338,32 +1500,37 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
-                                    "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object"
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                   },
                                   "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                     "enum": [
                                       "public",
                                       "internal",
                                       "none"
                                     ],
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
                                     "type": "string"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Path of the endpoint URL"
                                   },
                                   "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                    "type": "string"
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                   },
                                   "secure": {
                                     "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean"
+                                    "type": "boolean",
+                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                   },
                                   "targetPort": {
                                     "type": "integer"
@@ -1379,21 +1546,25 @@
                             },
                             "inlined": {
                               "description": "Inlined manifest",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined manifest"
                             },
                             "name": {
                               "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                             },
                             "uri": {
                               "description": "Location in a file fetched from a uri.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location in a file fetched from a uri."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for a Kubernetes component",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -1418,32 +1589,37 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
-                                    "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object"
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                   },
                                   "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                     "enum": [
                                       "public",
                                       "internal",
                                       "none"
                                     ],
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
                                     "type": "string"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
-                                    "type": "string"
+                                    "type": "string",
+                                    "markdownDescription": "Path of the endpoint URL"
                                   },
                                   "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                    "type": "string"
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                   },
                                   "secure": {
                                     "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean"
+                                    "type": "boolean",
+                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                   },
                                   "targetPort": {
                                     "type": "integer"
@@ -1459,21 +1635,25 @@
                             },
                             "inlined": {
                               "description": "Inlined manifest",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Inlined manifest"
                             },
                             "name": {
                               "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                             },
                             "uri": {
                               "description": "Location in a file fetched from a uri.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Location in a file fetched from a uri."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for an OpenShift component",
                           "additionalProperties": false,
                           "oneOf": [
                             {
@@ -1493,17 +1673,20 @@
                           "properties": {
                             "name": {
                               "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                             },
                             "size": {
                               "description": "Size of the volume",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Size of the volume"
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Configuration overriding for a Volume component",
                           "additionalProperties": false
                         }
                       },
@@ -1532,11 +1715,13 @@
                         }
                       ]
                     },
-                    "type": "array"
+                    "type": "array",
+                    "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge"
                   },
                   "id": {
                     "description": "Id in a registry that contains a Devfile yaml file",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Id in a registry that contains a Devfile yaml file"
                   },
                   "kubernetes": {
                     "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -1552,21 +1737,25 @@
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                     "additionalProperties": false
                   },
                   "name": {
                     "description": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)"
                   },
                   "registryUrl": {
                     "type": "string"
                   },
                   "uri": {
                     "description": "Uri of a Devfile yaml file",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Uri of a Devfile yaml file"
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                 "additionalProperties": false,
                 "oneOf": [
                   {
@@ -1591,17 +1780,20 @@
                 "properties": {
                   "name": {
                     "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                   },
                   "size": {
                     "description": "Size of the volume",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Size of the volume"
                   }
                 },
                 "required": [
                   "name"
                 ],
                 "type": "object",
+                "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
                 "additionalProperties": false
               }
             },
@@ -1640,7 +1832,8 @@
               }
             ]
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components"
         },
         "events": {
           "description": "Bindings of commands to events. Each command is referred-to by its name.",
@@ -1650,31 +1843,36 @@
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser."
             },
             "postStop": {
               "description": "Names of commands that should be executed after stopping the workspace.",
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed after stopping the workspace."
             },
             "preStart": {
               "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD."
             },
             "preStop": {
               "description": "Names of commands that should be executed before stopping the workspace.",
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Names of commands that should be executed before stopping the workspace."
             }
           },
           "type": "object",
+          "markdownDescription": "Bindings of commands to events. Each command is referred-to by its name.",
           "additionalProperties": false
         },
         "parent": {
@@ -1685,25 +1883,28 @@
               "items": {
                 "properties": {
                   "apply": {
-                    "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                    "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                     "properties": {
                       "attributes": {
                         "additionalProperties": {
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "component": {
                         "description": "Describes component that will be applied",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Describes component that will be applied"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -1713,28 +1914,33 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "label": {
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                     "additionalProperties": false
                   },
                   "composite": {
@@ -1745,21 +1951,24 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commands": {
                         "description": "The commands that comprise this composite command",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "The commands that comprise this composite command"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -1769,32 +1978,38 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "label": {
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "parallel": {
                         "description": "Indicates if the sub-commands should be executed concurrently",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                     "additionalProperties": false
                   },
                   "custom": {
@@ -1805,22 +2020,26 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandClass": {
                         "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                       },
                       "embeddedResource": {
                         "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -1830,22 +2049,26 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "label": {
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       }
                     },
                     "required": [
@@ -1854,6 +2077,7 @@
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                     "additionalProperties": false
                   },
                   "exec": {
@@ -1864,15 +2088,18 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
                         "description": "The actual command-line string",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The actual command-line string"
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Describes component to which given action relates"
                       },
                       "env": {
                         "description": "Optional list of environment variables that have to be set before running the command",
@@ -1892,14 +2119,16 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -1909,32 +2138,38 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "label": {
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Working directory where the command should be executed"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "CLI Command executed in an existing component container",
                     "additionalProperties": false
                   },
                   "vscodeLaunch": {
@@ -1945,14 +2180,16 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -1962,32 +2199,38 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "inlined": {
                         "description": "Inlined content of the VsCode configuration",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Inlined content of the VsCode configuration"
                       },
                       "uri": {
                         "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Command providing the definition of a VsCode launch action",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -2010,14 +2253,16 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -2027,32 +2272,38 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "inlined": {
                         "description": "Inlined content of the VsCode configuration",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Inlined content of the VsCode configuration"
                       },
                       "uri": {
                         "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Command providing the definition of a VsCode Task",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -2103,7 +2354,8 @@
                   }
                 ]
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Predefined, ready-to-use, workspace-related commands"
             },
             "components": {
               "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
@@ -2113,22 +2365,25 @@
                     "description": "Allows adding and configuring workspace-related containers",
                     "properties": {
                       "args": {
-                        "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                        "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                       },
                       "command": {
-                        "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                        "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                       },
                       "dedicatedPod": {
-                        "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                        "type": "boolean"
+                        "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                        "type": "boolean",
+                        "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                       },
                       "endpoints": {
                         "items": {
@@ -2137,32 +2392,37 @@
                               "additionalProperties": {
                                 "type": "string"
                               },
-                              "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                              "type": "object"
+                              "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                              "type": "object",
+                              "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                             },
                             "exposure": {
-                              "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                              "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                               "enum": [
                                 "public",
                                 "internal",
                                 "none"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
                               "type": "string"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Path of the endpoint URL"
                             },
                             "protocol": {
-                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                              "type": "string"
+                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                              "type": "string",
+                              "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                             },
                             "secure": {
                               "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                             },
                             "targetPort": {
                               "type": "integer"
@@ -2194,7 +2454,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "Environment variables used in this container"
                       },
                       "image": {
                         "type": "string"
@@ -2210,7 +2471,8 @@
                       },
                       "sourceMapping": {
                         "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                       },
                       "volumeMounts": {
                         "description": "List of volumes mounts that should be mounted is this container.",
@@ -2219,26 +2481,31 @@
                           "properties": {
                             "name": {
                               "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                             },
                             "path": {
                               "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Volume that should be mounted to a component container",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "List of volumes mounts that should be mounted is this container."
                       }
                     },
                     "required": [
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Allows adding and configuring workspace-related containers",
                     "additionalProperties": false
                   },
                   "custom": {
@@ -2246,15 +2513,18 @@
                     "properties": {
                       "componentClass": {
                         "description": "Class of component that the associated implementation controller should use to process this command with the appropriate logic",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Class of component that the associated implementation controller should use to process this command with the appropriate logic"
                       },
                       "embeddedResource": {
                         "description": "Additional free-form configuration for this custom component that the implementation controller will know how to use",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Additional free-form configuration for this custom component that the implementation controller will know how to use"
                       },
                       "name": {
                         "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                       }
                     },
                     "required": [
@@ -2263,6 +2533,7 @@
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Custom component whose logic is implementation-dependant and should be provided by the user possibly through some dedicated controller",
                     "additionalProperties": false
                   },
                   "kubernetes": {
@@ -2275,32 +2546,37 @@
                               "additionalProperties": {
                                 "type": "string"
                               },
-                              "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                              "type": "object"
+                              "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                              "type": "object",
+                              "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                             },
                             "exposure": {
-                              "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                              "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                               "enum": [
                                 "public",
                                 "internal",
                                 "none"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
                               "type": "string"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Path of the endpoint URL"
                             },
                             "protocol": {
-                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                              "type": "string"
+                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                              "type": "string",
+                              "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                             },
                             "secure": {
                               "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                             },
                             "targetPort": {
                               "type": "integer"
@@ -2316,21 +2592,25 @@
                       },
                       "inlined": {
                         "description": "Inlined manifest",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Inlined manifest"
                       },
                       "name": {
                         "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                       },
                       "uri": {
                         "description": "Location in a file fetched from a uri.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Location in a file fetched from a uri."
                       }
                     },
                     "required": [
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -2355,32 +2635,37 @@
                               "additionalProperties": {
                                 "type": "string"
                               },
-                              "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                              "type": "object"
+                              "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                              "type": "object",
+                              "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                             },
                             "exposure": {
-                              "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                              "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                               "enum": [
                                 "public",
                                 "internal",
                                 "none"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
                               "type": "string"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Path of the endpoint URL"
                             },
                             "protocol": {
-                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                              "type": "string"
+                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                              "type": "string",
+                              "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                             },
                             "secure": {
                               "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                             },
                             "targetPort": {
                               "type": "integer"
@@ -2396,21 +2681,25 @@
                       },
                       "inlined": {
                         "description": "Inlined manifest",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Inlined manifest"
                       },
                       "name": {
                         "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                       },
                       "uri": {
                         "description": "Location in a file fetched from a uri.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Location in a file fetched from a uri."
                       }
                     },
                     "required": [
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -2426,32 +2715,35 @@
                     ]
                   },
                   "plugin": {
-                    "description": "Allows importing a plugin. \n Plugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+                    "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                     "properties": {
                       "commands": {
                         "description": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge",
                         "items": {
                           "properties": {
                             "apply": {
-                              "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                              "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                               "properties": {
                                 "attributes": {
                                   "additionalProperties": {
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "component": {
                                   "description": "Describes component that will be applied",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Describes component that will be applied"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -2461,28 +2753,33 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "label": {
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                               "additionalProperties": false
                             },
                             "composite": {
@@ -2493,21 +2790,24 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commands": {
                                   "description": "The commands that comprise this composite command",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "The commands that comprise this composite command"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -2517,32 +2817,38 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "label": {
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "parallel": {
                                   "description": "Indicates if the sub-commands should be executed concurrently",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                               "additionalProperties": false
                             },
                             "custom": {
@@ -2553,22 +2859,26 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandClass": {
                                   "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                                 },
                                 "embeddedResource": {
                                   "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -2578,22 +2888,26 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "label": {
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 }
                               },
                               "required": [
@@ -2602,6 +2916,7 @@
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                               "additionalProperties": false
                             },
                             "exec": {
@@ -2612,15 +2927,18 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
                                   "description": "The actual command-line string",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "The actual command-line string"
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Describes component to which given action relates"
                                 },
                                 "env": {
                                   "description": "Optional list of environment variables that have to be set before running the command",
@@ -2640,14 +2958,16 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -2657,32 +2977,38 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "label": {
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Working directory where the command should be executed"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "CLI Command executed in an existing component container",
                               "additionalProperties": false
                             },
                             "vscodeLaunch": {
@@ -2693,14 +3019,16 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -2710,32 +3038,38 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "inlined": {
                                   "description": "Inlined content of the VsCode configuration",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Inlined content of the VsCode configuration"
                                 },
                                 "uri": {
                                   "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Command providing the definition of a VsCode launch action",
                               "additionalProperties": false,
                               "oneOf": [
                                 {
@@ -2758,14 +3092,16 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -2775,32 +3111,38 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "inlined": {
                                   "description": "Inlined content of the VsCode configuration",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Inlined content of the VsCode configuration"
                                 },
                                 "uri": {
                                   "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Command providing the definition of a VsCode Task",
                               "additionalProperties": false,
                               "oneOf": [
                                 {
@@ -2851,7 +3193,8 @@
                             }
                           ]
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge"
                       },
                       "components": {
                         "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge",
@@ -2861,22 +3204,25 @@
                               "description": "Configuration overriding for a Container component",
                               "properties": {
                                 "args": {
-                                  "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                                  "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                                 },
                                 "command": {
-                                  "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                                  "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                                 },
                                 "dedicatedPod": {
-                                  "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                                  "type": "boolean"
+                                  "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                                  "type": "boolean",
+                                  "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                                 },
                                 "endpoints": {
                                   "items": {
@@ -2885,32 +3231,37 @@
                                         "additionalProperties": {
                                           "type": "string"
                                         },
-                                        "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                        "type": "object"
+                                        "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                        "type": "object",
+                                        "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                       },
                                       "exposure": {
-                                        "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                        "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                         "enum": [
                                           "public",
                                           "internal",
                                           "none"
                                         ],
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
                                         "type": "string"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Path of the endpoint URL"
                                       },
                                       "protocol": {
-                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                        "type": "string"
+                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                        "type": "string",
+                                        "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                       },
                                       "secure": {
                                         "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                        "type": "boolean"
+                                        "type": "boolean",
+                                        "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                       },
                                       "targetPort": {
                                         "type": "integer"
@@ -2942,7 +3293,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "Environment variables used in this container"
                                 },
                                 "image": {
                                   "type": "string"
@@ -2958,7 +3310,8 @@
                                 },
                                 "sourceMapping": {
                                   "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                                 },
                                 "volumeMounts": {
                                   "description": "List of volumes mounts that should be mounted is this container.",
@@ -2967,26 +3320,31 @@
                                     "properties": {
                                       "name": {
                                         "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                       },
                                       "path": {
                                         "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                                       }
                                     },
                                     "required": [
                                       "name"
                                     ],
                                     "type": "object",
+                                    "markdownDescription": "Volume that should be mounted to a component container",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "List of volumes mounts that should be mounted is this container."
                                 }
                               },
                               "required": [
                                 "name"
                               ],
                               "type": "object",
+                              "markdownDescription": "Configuration overriding for a Container component",
                               "additionalProperties": false
                             },
                             "kubernetes": {
@@ -2999,32 +3357,37 @@
                                         "additionalProperties": {
                                           "type": "string"
                                         },
-                                        "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                        "type": "object"
+                                        "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                        "type": "object",
+                                        "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                       },
                                       "exposure": {
-                                        "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                        "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                         "enum": [
                                           "public",
                                           "internal",
                                           "none"
                                         ],
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
                                         "type": "string"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Path of the endpoint URL"
                                       },
                                       "protocol": {
-                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                        "type": "string"
+                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                        "type": "string",
+                                        "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                       },
                                       "secure": {
                                         "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                        "type": "boolean"
+                                        "type": "boolean",
+                                        "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                       },
                                       "targetPort": {
                                         "type": "integer"
@@ -3040,21 +3403,25 @@
                                 },
                                 "inlined": {
                                   "description": "Inlined manifest",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Inlined manifest"
                                 },
                                 "name": {
                                   "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                                 },
                                 "uri": {
                                   "description": "Location in a file fetched from a uri.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Location in a file fetched from a uri."
                                 }
                               },
                               "required": [
                                 "name"
                               ],
                               "type": "object",
+                              "markdownDescription": "Configuration overriding for a Kubernetes component",
                               "additionalProperties": false,
                               "oneOf": [
                                 {
@@ -3079,32 +3446,37 @@
                                         "additionalProperties": {
                                           "type": "string"
                                         },
-                                        "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                        "type": "object"
+                                        "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                        "type": "object",
+                                        "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                       },
                                       "exposure": {
-                                        "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                        "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                         "enum": [
                                           "public",
                                           "internal",
                                           "none"
                                         ],
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
                                         "type": "string"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Path of the endpoint URL"
                                       },
                                       "protocol": {
-                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                        "type": "string"
+                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                        "type": "string",
+                                        "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                       },
                                       "secure": {
                                         "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                        "type": "boolean"
+                                        "type": "boolean",
+                                        "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                       },
                                       "targetPort": {
                                         "type": "integer"
@@ -3120,21 +3492,25 @@
                                 },
                                 "inlined": {
                                   "description": "Inlined manifest",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Inlined manifest"
                                 },
                                 "name": {
                                   "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                                 },
                                 "uri": {
                                   "description": "Location in a file fetched from a uri.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Location in a file fetched from a uri."
                                 }
                               },
                               "required": [
                                 "name"
                               ],
                               "type": "object",
+                              "markdownDescription": "Configuration overriding for an OpenShift component",
                               "additionalProperties": false,
                               "oneOf": [
                                 {
@@ -3154,17 +3530,20 @@
                               "properties": {
                                 "name": {
                                   "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                                 },
                                 "size": {
                                   "description": "Size of the volume",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Size of the volume"
                                 }
                               },
                               "required": [
                                 "name"
                               ],
                               "type": "object",
+                              "markdownDescription": "Configuration overriding for a Volume component",
                               "additionalProperties": false
                             }
                           },
@@ -3193,11 +3572,13 @@
                             }
                           ]
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge"
                       },
                       "id": {
                         "description": "Id in a registry that contains a Devfile yaml file",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Id in a registry that contains a Devfile yaml file"
                       },
                       "kubernetes": {
                         "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -3213,21 +3594,25 @@
                           "name"
                         ],
                         "type": "object",
+                        "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                         "additionalProperties": false
                       },
                       "name": {
                         "description": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)"
                       },
                       "registryUrl": {
                         "type": "string"
                       },
                       "uri": {
                         "description": "Uri of a Devfile yaml file",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Uri of a Devfile yaml file"
                       }
                     },
                     "type": "object",
+                    "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -3252,17 +3637,20 @@
                     "properties": {
                       "name": {
                         "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                       },
                       "size": {
                         "description": "Size of the volume",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Size of the volume"
                       }
                     },
                     "required": [
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
                     "additionalProperties": false
                   }
                 },
@@ -3301,7 +3689,8 @@
                   }
                 ]
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components"
             },
             "events": {
               "description": "Bindings of commands to events. Each command is referred-to by its name.",
@@ -3311,36 +3700,42 @@
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser."
                 },
                 "postStop": {
                   "description": "Names of commands that should be executed after stopping the workspace.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Names of commands that should be executed after stopping the workspace."
                 },
                 "preStart": {
                   "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD."
                 },
                 "preStop": {
                   "description": "Names of commands that should be executed before stopping the workspace.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Names of commands that should be executed before stopping the workspace."
                 }
               },
               "type": "object",
+              "markdownDescription": "Bindings of commands to events. Each command is referred-to by its name.",
               "additionalProperties": false
             },
             "id": {
               "description": "Id in a registry that contains a Devfile yaml file",
-              "type": "string"
+              "type": "string",
+              "markdownDescription": "Id in a registry that contains a Devfile yaml file"
             },
             "kubernetes": {
               "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -3356,6 +3751,7 @@
                 "name"
               ],
               "type": "object",
+              "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
               "additionalProperties": false
             },
             "projects": {
@@ -3364,7 +3760,8 @@
                 "properties": {
                   "clonePath": {
                     "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
                   },
                   "custom": {
                     "description": "Project's Custom source",
@@ -3381,6 +3778,7 @@
                       "projectSourceClass"
                     ],
                     "type": "object",
+                    "markdownDescription": "Project's Custom source",
                     "additionalProperties": false
                   },
                   "git": {
@@ -3388,22 +3786,27 @@
                     "properties": {
                       "branch": {
                         "description": "The branch to check",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The branch to check"
                       },
                       "location": {
                         "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                       },
                       "sparseCheckoutDir": {
                         "description": "Part of project to populate in the working directory.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Part of project to populate in the working directory."
                       },
                       "startPoint": {
                         "description": "The tag or commit id to reset the checked out branch to",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The tag or commit id to reset the checked out branch to"
                       }
                     },
                     "type": "object",
+                    "markdownDescription": "Project's Git source",
                     "additionalProperties": false
                   },
                   "github": {
@@ -3411,41 +3814,50 @@
                     "properties": {
                       "branch": {
                         "description": "The branch to check",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The branch to check"
                       },
                       "location": {
                         "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                       },
                       "sparseCheckoutDir": {
                         "description": "Part of project to populate in the working directory.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Part of project to populate in the working directory."
                       },
                       "startPoint": {
                         "description": "The tag or commit id to reset the checked out branch to",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The tag or commit id to reset the checked out branch to"
                       }
                     },
                     "type": "object",
+                    "markdownDescription": "Project's GitHub source",
                     "additionalProperties": false
                   },
                   "name": {
                     "description": "Project name",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project name"
                   },
                   "zip": {
                     "description": "Project's Zip source",
                     "properties": {
                       "location": {
                         "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                       },
                       "sparseCheckoutDir": {
                         "description": "Part of project to populate in the working directory.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Part of project to populate in the working directory."
                       }
                     },
                     "type": "object",
+                    "markdownDescription": "Project's Zip source",
                     "additionalProperties": false
                   }
                 },
@@ -3477,17 +3889,20 @@
                   }
                 ]
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Projects worked on in the workspace, containing names and sources locations"
             },
             "registryUrl": {
               "type": "string"
             },
             "uri": {
               "description": "Uri of a Devfile yaml file",
-              "type": "string"
+              "type": "string",
+              "markdownDescription": "Uri of a Devfile yaml file"
             }
           },
           "type": "object",
+          "markdownDescription": "Parent workspace template",
           "additionalProperties": false,
           "oneOf": [
             {
@@ -3513,7 +3928,8 @@
             "properties": {
               "clonePath": {
                 "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
               },
               "custom": {
                 "description": "Project's Custom source",
@@ -3530,6 +3946,7 @@
                   "projectSourceClass"
                 ],
                 "type": "object",
+                "markdownDescription": "Project's Custom source",
                 "additionalProperties": false
               },
               "git": {
@@ -3537,22 +3954,27 @@
                 "properties": {
                   "branch": {
                     "description": "The branch to check",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The branch to check"
                   },
                   "location": {
                     "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                   },
                   "sparseCheckoutDir": {
                     "description": "Part of project to populate in the working directory.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Part of project to populate in the working directory."
                   },
                   "startPoint": {
                     "description": "The tag or commit id to reset the checked out branch to",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The tag or commit id to reset the checked out branch to"
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Project's Git source",
                 "additionalProperties": false
               },
               "github": {
@@ -3560,41 +3982,50 @@
                 "properties": {
                   "branch": {
                     "description": "The branch to check",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The branch to check"
                   },
                   "location": {
                     "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                   },
                   "sparseCheckoutDir": {
                     "description": "Part of project to populate in the working directory.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Part of project to populate in the working directory."
                   },
                   "startPoint": {
                     "description": "The tag or commit id to reset the checked out branch to",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "The tag or commit id to reset the checked out branch to"
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Project's GitHub source",
                 "additionalProperties": false
               },
               "name": {
                 "description": "Project name",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Project name"
               },
               "zip": {
                 "description": "Project's Zip source",
                 "properties": {
                   "location": {
                     "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                   },
                   "sparseCheckoutDir": {
                     "description": "Part of project to populate in the working directory.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Part of project to populate in the working directory."
                   }
                 },
                 "type": "object",
+                "markdownDescription": "Project's Zip source",
                 "additionalProperties": false
               }
             },
@@ -3626,13 +4057,16 @@
               }
             ]
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Projects worked on in the workspace, containing names and sources locations"
         }
       },
       "type": "object",
+      "markdownDescription": "Structure of the workspace. This is also the specification of a workspace template.",
       "additionalProperties": false
     }
   },
   "type": "object",
+  "markdownDescription": "DevWorkspaceTemplate is the Schema for the devworkspacetemplates API",
   "additionalProperties": false
 }

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -3,11 +3,13 @@
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
+      "type": "string",
+      "markdownDescription": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
+      "type": "string",
+      "markdownDescription": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata": {
       "type": "object",
@@ -30,25 +32,28 @@
               "items": {
                 "properties": {
                   "apply": {
-                    "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                    "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                     "properties": {
                       "attributes": {
                         "additionalProperties": {
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "component": {
                         "description": "Describes component that will be applied",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Describes component that will be applied"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -58,28 +63,33 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "label": {
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                     "additionalProperties": false
                   },
                   "composite": {
@@ -90,21 +100,24 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commands": {
                         "description": "The commands that comprise this composite command",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "The commands that comprise this composite command"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -114,32 +127,38 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "label": {
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "parallel": {
                         "description": "Indicates if the sub-commands should be executed concurrently",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                     "additionalProperties": false
                   },
                   "custom": {
@@ -150,22 +169,26 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandClass": {
                         "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                       },
                       "embeddedResource": {
                         "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -175,22 +198,26 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "label": {
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       }
                     },
                     "required": [
@@ -199,6 +226,7 @@
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                     "additionalProperties": false
                   },
                   "exec": {
@@ -209,15 +237,18 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
                         "description": "The actual command-line string",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The actual command-line string"
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Describes component to which given action relates"
                       },
                       "env": {
                         "description": "Optional list of environment variables that have to be set before running the command",
@@ -237,14 +268,16 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -254,26 +287,31 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "label": {
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Working directory where the command should be executed"
                       }
                     },
                     "required": [
@@ -281,6 +319,7 @@
                       "commandLine"
                     ],
                     "type": "object",
+                    "markdownDescription": "CLI Command executed in an existing component container",
                     "additionalProperties": false
                   },
                   "vscodeLaunch": {
@@ -291,14 +330,16 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -308,32 +349,38 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "inlined": {
                         "description": "Inlined content of the VsCode configuration",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Inlined content of the VsCode configuration"
                       },
                       "uri": {
                         "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Command providing the definition of a VsCode launch action",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -356,14 +403,16 @@
                           "type": "string"
                         },
                         "description": "Optional map of free-form additional command attributes",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "group": {
                         "description": "Defines the group this command is part of",
                         "properties": {
                           "isDefault": {
                             "description": "Identifies the default command for a given group kind",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Identifies the default command for a given group kind"
                           },
                           "kind": {
                             "description": "Kind of group the command is part of",
@@ -373,32 +422,38 @@
                               "test",
                               "debug"
                             ],
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Kind of group the command is part of"
                           }
                         },
                         "required": [
                           "kind"
                         ],
                         "type": "object",
+                        "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "inlined": {
                         "description": "Inlined content of the VsCode configuration",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Inlined content of the VsCode configuration"
                       },
                       "uri": {
                         "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "type": "object",
+                    "markdownDescription": "Command providing the definition of a VsCode Task",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -449,7 +504,8 @@
                   }
                 ]
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Predefined, ready-to-use, workspace-related commands"
             },
             "components": {
               "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
@@ -459,22 +515,25 @@
                     "description": "Allows adding and configuring workspace-related containers",
                     "properties": {
                       "args": {
-                        "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                        "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                       },
                       "command": {
-                        "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                        "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                       },
                       "dedicatedPod": {
-                        "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                        "type": "boolean"
+                        "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                        "type": "boolean",
+                        "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                       },
                       "endpoints": {
                         "items": {
@@ -483,32 +542,37 @@
                               "additionalProperties": {
                                 "type": "string"
                               },
-                              "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                              "type": "object"
+                              "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                              "type": "object",
+                              "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                             },
                             "exposure": {
-                              "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                              "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                               "enum": [
                                 "public",
                                 "internal",
                                 "none"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
                               "type": "string"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Path of the endpoint URL"
                             },
                             "protocol": {
-                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                              "type": "string"
+                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                              "type": "string",
+                              "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                             },
                             "secure": {
                               "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                             },
                             "targetPort": {
                               "type": "integer"
@@ -541,7 +605,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "Environment variables used in this container"
                       },
                       "image": {
                         "type": "string"
@@ -557,7 +622,8 @@
                       },
                       "sourceMapping": {
                         "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                       },
                       "volumeMounts": {
                         "description": "List of volumes mounts that should be mounted is this container.",
@@ -566,20 +632,24 @@
                           "properties": {
                             "name": {
                               "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                             },
                             "path": {
                               "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                             }
                           },
                           "required": [
                             "name"
                           ],
                           "type": "object",
+                          "markdownDescription": "Volume that should be mounted to a component container",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "List of volumes mounts that should be mounted is this container."
                       }
                     },
                     "required": [
@@ -587,6 +657,7 @@
                       "image"
                     ],
                     "type": "object",
+                    "markdownDescription": "Allows adding and configuring workspace-related containers",
                     "additionalProperties": false
                   },
                   "custom": {
@@ -594,15 +665,18 @@
                     "properties": {
                       "componentClass": {
                         "description": "Class of component that the associated implementation controller should use to process this command with the appropriate logic",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Class of component that the associated implementation controller should use to process this command with the appropriate logic"
                       },
                       "embeddedResource": {
                         "description": "Additional free-form configuration for this custom component that the implementation controller will know how to use",
-                        "type": "object"
+                        "type": "object",
+                        "markdownDescription": "Additional free-form configuration for this custom component that the implementation controller will know how to use"
                       },
                       "name": {
                         "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                       }
                     },
                     "required": [
@@ -611,6 +685,7 @@
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Custom component whose logic is implementation-dependant and should be provided by the user possibly through some dedicated controller",
                     "additionalProperties": false
                   },
                   "kubernetes": {
@@ -623,32 +698,37 @@
                               "additionalProperties": {
                                 "type": "string"
                               },
-                              "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                              "type": "object"
+                              "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                              "type": "object",
+                              "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                             },
                             "exposure": {
-                              "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                              "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                               "enum": [
                                 "public",
                                 "internal",
                                 "none"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
                               "type": "string"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Path of the endpoint URL"
                             },
                             "protocol": {
-                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                              "type": "string"
+                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                              "type": "string",
+                              "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                             },
                             "secure": {
                               "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                             },
                             "targetPort": {
                               "type": "integer"
@@ -664,21 +744,25 @@
                       },
                       "inlined": {
                         "description": "Inlined manifest",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Inlined manifest"
                       },
                       "name": {
                         "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                       },
                       "uri": {
                         "description": "Location in a file fetched from a uri.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Location in a file fetched from a uri."
                       }
                     },
                     "required": [
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -703,32 +787,37 @@
                               "additionalProperties": {
                                 "type": "string"
                               },
-                              "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                              "type": "object"
+                              "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                              "type": "object",
+                              "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                             },
                             "exposure": {
-                              "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                              "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                               "enum": [
                                 "public",
                                 "internal",
                                 "none"
                               ],
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
                               "type": "string"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
-                              "type": "string"
+                              "type": "string",
+                              "markdownDescription": "Path of the endpoint URL"
                             },
                             "protocol": {
-                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                              "type": "string"
+                              "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                              "type": "string",
+                              "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                             },
                             "secure": {
                               "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                             },
                             "targetPort": {
                               "type": "integer"
@@ -744,21 +833,25 @@
                       },
                       "inlined": {
                         "description": "Inlined manifest",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Inlined manifest"
                       },
                       "name": {
                         "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                       },
                       "uri": {
                         "description": "Location in a file fetched from a uri.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Location in a file fetched from a uri."
                       }
                     },
                     "required": [
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -774,32 +867,35 @@
                     ]
                   },
                   "plugin": {
-                    "description": "Allows importing a plugin. \n Plugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+                    "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                     "properties": {
                       "commands": {
                         "description": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge",
                         "items": {
                           "properties": {
                             "apply": {
-                              "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                              "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                               "properties": {
                                 "attributes": {
                                   "additionalProperties": {
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "component": {
                                   "description": "Describes component that will be applied",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Describes component that will be applied"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -809,28 +905,33 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "label": {
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                               "additionalProperties": false
                             },
                             "composite": {
@@ -841,21 +942,24 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commands": {
                                   "description": "The commands that comprise this composite command",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "The commands that comprise this composite command"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -865,32 +969,38 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "label": {
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "parallel": {
                                   "description": "Indicates if the sub-commands should be executed concurrently",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                               "additionalProperties": false
                             },
                             "custom": {
@@ -901,22 +1011,26 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandClass": {
                                   "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                                 },
                                 "embeddedResource": {
                                   "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -926,22 +1040,26 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "label": {
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 }
                               },
                               "required": [
@@ -950,6 +1068,7 @@
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                               "additionalProperties": false
                             },
                             "exec": {
@@ -960,15 +1079,18 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
                                   "description": "The actual command-line string",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "The actual command-line string"
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Describes component to which given action relates"
                                 },
                                 "env": {
                                   "description": "Optional list of environment variables that have to be set before running the command",
@@ -988,14 +1110,16 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -1005,32 +1129,38 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "label": {
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Working directory where the command should be executed"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "CLI Command executed in an existing component container",
                               "additionalProperties": false
                             },
                             "vscodeLaunch": {
@@ -1041,14 +1171,16 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -1058,32 +1190,38 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "inlined": {
                                   "description": "Inlined content of the VsCode configuration",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Inlined content of the VsCode configuration"
                                 },
                                 "uri": {
                                   "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Command providing the definition of a VsCode launch action",
                               "additionalProperties": false,
                               "oneOf": [
                                 {
@@ -1106,14 +1244,16 @@
                                     "type": "string"
                                   },
                                   "description": "Optional map of free-form additional command attributes",
-                                  "type": "object"
+                                  "type": "object",
+                                  "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "group": {
                                   "description": "Defines the group this command is part of",
                                   "properties": {
                                     "isDefault": {
                                       "description": "Identifies the default command for a given group kind",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Identifies the default command for a given group kind"
                                     },
                                     "kind": {
                                       "description": "Kind of group the command is part of",
@@ -1123,32 +1263,38 @@
                                         "test",
                                         "debug"
                                       ],
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Kind of group the command is part of"
                                     }
                                   },
                                   "required": [
                                     "kind"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "inlined": {
                                   "description": "Inlined content of the VsCode configuration",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Inlined content of the VsCode configuration"
                                 },
                                 "uri": {
                                   "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                                 }
                               },
                               "required": [
                                 "id"
                               ],
                               "type": "object",
+                              "markdownDescription": "Command providing the definition of a VsCode Task",
                               "additionalProperties": false,
                               "oneOf": [
                                 {
@@ -1199,7 +1345,8 @@
                             }
                           ]
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge"
                       },
                       "components": {
                         "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge",
@@ -1209,22 +1356,25 @@
                               "description": "Configuration overriding for a Container component",
                               "properties": {
                                 "args": {
-                                  "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                                  "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                                 },
                                 "command": {
-                                  "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                                  "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                                 },
                                 "dedicatedPod": {
-                                  "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                                  "type": "boolean"
+                                  "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                                  "type": "boolean",
+                                  "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                                 },
                                 "endpoints": {
                                   "items": {
@@ -1233,32 +1383,37 @@
                                         "additionalProperties": {
                                           "type": "string"
                                         },
-                                        "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                        "type": "object"
+                                        "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                        "type": "object",
+                                        "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                       },
                                       "exposure": {
-                                        "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                        "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                         "enum": [
                                           "public",
                                           "internal",
                                           "none"
                                         ],
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
                                         "type": "string"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Path of the endpoint URL"
                                       },
                                       "protocol": {
-                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                        "type": "string"
+                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                        "type": "string",
+                                        "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                       },
                                       "secure": {
                                         "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                        "type": "boolean"
+                                        "type": "boolean",
+                                        "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                       },
                                       "targetPort": {
                                         "type": "integer"
@@ -1290,7 +1445,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "Environment variables used in this container"
                                 },
                                 "image": {
                                   "type": "string"
@@ -1306,7 +1462,8 @@
                                 },
                                 "sourceMapping": {
                                   "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                                 },
                                 "volumeMounts": {
                                   "description": "List of volumes mounts that should be mounted is this container.",
@@ -1315,26 +1472,31 @@
                                     "properties": {
                                       "name": {
                                         "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                       },
                                       "path": {
                                         "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                                       }
                                     },
                                     "required": [
                                       "name"
                                     ],
                                     "type": "object",
+                                    "markdownDescription": "Volume that should be mounted to a component container",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "markdownDescription": "List of volumes mounts that should be mounted is this container."
                                 }
                               },
                               "required": [
                                 "name"
                               ],
                               "type": "object",
+                              "markdownDescription": "Configuration overriding for a Container component",
                               "additionalProperties": false
                             },
                             "kubernetes": {
@@ -1347,32 +1509,37 @@
                                         "additionalProperties": {
                                           "type": "string"
                                         },
-                                        "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                        "type": "object"
+                                        "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                        "type": "object",
+                                        "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                       },
                                       "exposure": {
-                                        "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                        "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                         "enum": [
                                           "public",
                                           "internal",
                                           "none"
                                         ],
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
                                         "type": "string"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Path of the endpoint URL"
                                       },
                                       "protocol": {
-                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                        "type": "string"
+                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                        "type": "string",
+                                        "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                       },
                                       "secure": {
                                         "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                        "type": "boolean"
+                                        "type": "boolean",
+                                        "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                       },
                                       "targetPort": {
                                         "type": "integer"
@@ -1388,21 +1555,25 @@
                                 },
                                 "inlined": {
                                   "description": "Inlined manifest",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Inlined manifest"
                                 },
                                 "name": {
                                   "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                                 },
                                 "uri": {
                                   "description": "Location in a file fetched from a uri.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Location in a file fetched from a uri."
                                 }
                               },
                               "required": [
                                 "name"
                               ],
                               "type": "object",
+                              "markdownDescription": "Configuration overriding for a Kubernetes component",
                               "additionalProperties": false,
                               "oneOf": [
                                 {
@@ -1427,32 +1598,37 @@
                                         "additionalProperties": {
                                           "type": "string"
                                         },
-                                        "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                        "type": "object"
+                                        "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                        "type": "object",
+                                        "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                       },
                                       "exposure": {
-                                        "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                        "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                         "enum": [
                                           "public",
                                           "internal",
                                           "none"
                                         ],
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
                                         "type": "string"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
-                                        "type": "string"
+                                        "type": "string",
+                                        "markdownDescription": "Path of the endpoint URL"
                                       },
                                       "protocol": {
-                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                        "type": "string"
+                                        "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                        "type": "string",
+                                        "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                       },
                                       "secure": {
                                         "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                        "type": "boolean"
+                                        "type": "boolean",
+                                        "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                       },
                                       "targetPort": {
                                         "type": "integer"
@@ -1468,21 +1644,25 @@
                                 },
                                 "inlined": {
                                   "description": "Inlined manifest",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Inlined manifest"
                                 },
                                 "name": {
                                   "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                                 },
                                 "uri": {
                                   "description": "Location in a file fetched from a uri.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Location in a file fetched from a uri."
                                 }
                               },
                               "required": [
                                 "name"
                               ],
                               "type": "object",
+                              "markdownDescription": "Configuration overriding for an OpenShift component",
                               "additionalProperties": false,
                               "oneOf": [
                                 {
@@ -1502,17 +1682,20 @@
                               "properties": {
                                 "name": {
                                   "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                                 },
                                 "size": {
                                   "description": "Size of the volume",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Size of the volume"
                                 }
                               },
                               "required": [
                                 "name"
                               ],
                               "type": "object",
+                              "markdownDescription": "Configuration overriding for a Volume component",
                               "additionalProperties": false
                             }
                           },
@@ -1541,11 +1724,13 @@
                             }
                           ]
                         },
-                        "type": "array"
+                        "type": "array",
+                        "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge"
                       },
                       "id": {
                         "description": "Id in a registry that contains a Devfile yaml file",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Id in a registry that contains a Devfile yaml file"
                       },
                       "kubernetes": {
                         "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -1561,21 +1746,25 @@
                           "name"
                         ],
                         "type": "object",
+                        "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                         "additionalProperties": false
                       },
                       "name": {
                         "description": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)"
                       },
                       "registryUrl": {
                         "type": "string"
                       },
                       "uri": {
                         "description": "Uri of a Devfile yaml file",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Uri of a Devfile yaml file"
                       }
                     },
                     "type": "object",
+                    "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                     "additionalProperties": false,
                     "oneOf": [
                       {
@@ -1600,17 +1789,20 @@
                     "properties": {
                       "name": {
                         "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                       },
                       "size": {
                         "description": "Size of the volume",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Size of the volume"
                       }
                     },
                     "required": [
                       "name"
                     ],
                     "type": "object",
+                    "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
                     "additionalProperties": false
                   }
                 },
@@ -1649,7 +1841,8 @@
                   }
                 ]
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components"
             },
             "events": {
               "description": "Bindings of commands to events. Each command is referred-to by its name.",
@@ -1659,31 +1852,36 @@
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser."
                 },
                 "postStop": {
                   "description": "Names of commands that should be executed after stopping the workspace.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Names of commands that should be executed after stopping the workspace."
                 },
                 "preStart": {
                   "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD."
                 },
                 "preStop": {
                   "description": "Names of commands that should be executed before stopping the workspace.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Names of commands that should be executed before stopping the workspace."
                 }
               },
               "type": "object",
+              "markdownDescription": "Bindings of commands to events. Each command is referred-to by its name.",
               "additionalProperties": false
             },
             "parent": {
@@ -1694,25 +1892,28 @@
                   "items": {
                     "properties": {
                       "apply": {
-                        "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                        "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                         "properties": {
                           "attributes": {
                             "additionalProperties": {
                               "type": "string"
                             },
                             "description": "Optional map of free-form additional command attributes",
-                            "type": "object"
+                            "type": "object",
+                            "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "component": {
                             "description": "Describes component that will be applied",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Describes component that will be applied"
                           },
                           "group": {
                             "description": "Defines the group this command is part of",
                             "properties": {
                               "isDefault": {
                                 "description": "Identifies the default command for a given group kind",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Identifies the default command for a given group kind"
                               },
                               "kind": {
                                 "description": "Kind of group the command is part of",
@@ -1722,28 +1923,33 @@
                                   "test",
                                   "debug"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Kind of group the command is part of"
                               }
                             },
                             "required": [
                               "kind"
                             ],
                             "type": "object",
+                            "markdownDescription": "Defines the group this command is part of",
                             "additionalProperties": false
                           },
                           "id": {
                             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                           },
                           "label": {
                             "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           }
                         },
                         "required": [
                           "id"
                         ],
                         "type": "object",
+                        "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                         "additionalProperties": false
                       },
                       "composite": {
@@ -1754,21 +1960,24 @@
                               "type": "string"
                             },
                             "description": "Optional map of free-form additional command attributes",
-                            "type": "object"
+                            "type": "object",
+                            "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "commands": {
                             "description": "The commands that comprise this composite command",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "markdownDescription": "The commands that comprise this composite command"
                           },
                           "group": {
                             "description": "Defines the group this command is part of",
                             "properties": {
                               "isDefault": {
                                 "description": "Identifies the default command for a given group kind",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Identifies the default command for a given group kind"
                               },
                               "kind": {
                                 "description": "Kind of group the command is part of",
@@ -1778,32 +1987,38 @@
                                   "test",
                                   "debug"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Kind of group the command is part of"
                               }
                             },
                             "required": [
                               "kind"
                             ],
                             "type": "object",
+                            "markdownDescription": "Defines the group this command is part of",
                             "additionalProperties": false
                           },
                           "id": {
                             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                           },
                           "label": {
                             "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "parallel": {
                             "description": "Indicates if the sub-commands should be executed concurrently",
-                            "type": "boolean"
+                            "type": "boolean",
+                            "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                           }
                         },
                         "required": [
                           "id"
                         ],
                         "type": "object",
+                        "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                         "additionalProperties": false
                       },
                       "custom": {
@@ -1814,22 +2029,26 @@
                               "type": "string"
                             },
                             "description": "Optional map of free-form additional command attributes",
-                            "type": "object"
+                            "type": "object",
+                            "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "commandClass": {
                             "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                           },
                           "embeddedResource": {
                             "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                            "type": "object"
+                            "type": "object",
+                            "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                           },
                           "group": {
                             "description": "Defines the group this command is part of",
                             "properties": {
                               "isDefault": {
                                 "description": "Identifies the default command for a given group kind",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Identifies the default command for a given group kind"
                               },
                               "kind": {
                                 "description": "Kind of group the command is part of",
@@ -1839,22 +2058,26 @@
                                   "test",
                                   "debug"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Kind of group the command is part of"
                               }
                             },
                             "required": [
                               "kind"
                             ],
                             "type": "object",
+                            "markdownDescription": "Defines the group this command is part of",
                             "additionalProperties": false
                           },
                           "id": {
                             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                           },
                           "label": {
                             "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           }
                         },
                         "required": [
@@ -1863,6 +2086,7 @@
                           "id"
                         ],
                         "type": "object",
+                        "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                         "additionalProperties": false
                       },
                       "exec": {
@@ -1873,15 +2097,18 @@
                               "type": "string"
                             },
                             "description": "Optional map of free-form additional command attributes",
-                            "type": "object"
+                            "type": "object",
+                            "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "commandLine": {
                             "description": "The actual command-line string",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "The actual command-line string"
                           },
                           "component": {
                             "description": "Describes component to which given action relates",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Describes component to which given action relates"
                           },
                           "env": {
                             "description": "Optional list of environment variables that have to be set before running the command",
@@ -1901,14 +2128,16 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                           },
                           "group": {
                             "description": "Defines the group this command is part of",
                             "properties": {
                               "isDefault": {
                                 "description": "Identifies the default command for a given group kind",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Identifies the default command for a given group kind"
                               },
                               "kind": {
                                 "description": "Kind of group the command is part of",
@@ -1918,32 +2147,38 @@
                                   "test",
                                   "debug"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Kind of group the command is part of"
                               }
                             },
                             "required": [
                               "kind"
                             ],
                             "type": "object",
+                            "markdownDescription": "Defines the group this command is part of",
                             "additionalProperties": false
                           },
                           "id": {
                             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                           },
                           "label": {
                             "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "workingDir": {
                             "description": "Working directory where the command should be executed",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Working directory where the command should be executed"
                           }
                         },
                         "required": [
                           "id"
                         ],
                         "type": "object",
+                        "markdownDescription": "CLI Command executed in an existing component container",
                         "additionalProperties": false
                       },
                       "vscodeLaunch": {
@@ -1954,14 +2189,16 @@
                               "type": "string"
                             },
                             "description": "Optional map of free-form additional command attributes",
-                            "type": "object"
+                            "type": "object",
+                            "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "group": {
                             "description": "Defines the group this command is part of",
                             "properties": {
                               "isDefault": {
                                 "description": "Identifies the default command for a given group kind",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Identifies the default command for a given group kind"
                               },
                               "kind": {
                                 "description": "Kind of group the command is part of",
@@ -1971,32 +2208,38 @@
                                   "test",
                                   "debug"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Kind of group the command is part of"
                               }
                             },
                             "required": [
                               "kind"
                             ],
                             "type": "object",
+                            "markdownDescription": "Defines the group this command is part of",
                             "additionalProperties": false
                           },
                           "id": {
                             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                           },
                           "inlined": {
                             "description": "Inlined content of the VsCode configuration",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Inlined content of the VsCode configuration"
                           },
                           "uri": {
                             "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                           }
                         },
                         "required": [
                           "id"
                         ],
                         "type": "object",
+                        "markdownDescription": "Command providing the definition of a VsCode launch action",
                         "additionalProperties": false,
                         "oneOf": [
                           {
@@ -2019,14 +2262,16 @@
                               "type": "string"
                             },
                             "description": "Optional map of free-form additional command attributes",
-                            "type": "object"
+                            "type": "object",
+                            "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "group": {
                             "description": "Defines the group this command is part of",
                             "properties": {
                               "isDefault": {
                                 "description": "Identifies the default command for a given group kind",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "markdownDescription": "Identifies the default command for a given group kind"
                               },
                               "kind": {
                                 "description": "Kind of group the command is part of",
@@ -2036,32 +2281,38 @@
                                   "test",
                                   "debug"
                                 ],
-                                "type": "string"
+                                "type": "string",
+                                "markdownDescription": "Kind of group the command is part of"
                               }
                             },
                             "required": [
                               "kind"
                             ],
                             "type": "object",
+                            "markdownDescription": "Defines the group this command is part of",
                             "additionalProperties": false
                           },
                           "id": {
                             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                           },
                           "inlined": {
                             "description": "Inlined content of the VsCode configuration",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Inlined content of the VsCode configuration"
                           },
                           "uri": {
                             "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                           }
                         },
                         "required": [
                           "id"
                         ],
                         "type": "object",
+                        "markdownDescription": "Command providing the definition of a VsCode Task",
                         "additionalProperties": false,
                         "oneOf": [
                           {
@@ -2112,7 +2363,8 @@
                       }
                     ]
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Predefined, ready-to-use, workspace-related commands"
                 },
                 "components": {
                   "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
@@ -2122,22 +2374,25 @@
                         "description": "Allows adding and configuring workspace-related containers",
                         "properties": {
                           "args": {
-                            "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                            "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                           },
                           "command": {
-                            "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                            "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                           },
                           "dedicatedPod": {
-                            "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                            "type": "boolean"
+                            "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                            "type": "boolean",
+                            "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                           },
                           "endpoints": {
                             "items": {
@@ -2146,32 +2401,37 @@
                                   "additionalProperties": {
                                     "type": "string"
                                   },
-                                  "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                  "type": "object"
+                                  "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                  "type": "object",
+                                  "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                 },
                                 "exposure": {
-                                  "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                  "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                   "enum": [
                                     "public",
                                     "internal",
                                     "none"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                 },
                                 "name": {
                                   "type": "string"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Path of the endpoint URL"
                                 },
                                 "protocol": {
-                                  "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                  "type": "string"
+                                  "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                  "type": "string",
+                                  "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                 },
                                 "secure": {
                                   "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                 },
                                 "targetPort": {
                                   "type": "integer"
@@ -2203,7 +2463,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "markdownDescription": "Environment variables used in this container"
                           },
                           "image": {
                             "type": "string"
@@ -2219,7 +2480,8 @@
                           },
                           "sourceMapping": {
                             "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                           },
                           "volumeMounts": {
                             "description": "List of volumes mounts that should be mounted is this container.",
@@ -2228,26 +2490,31 @@
                               "properties": {
                                 "name": {
                                   "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                 },
                                 "path": {
                                   "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                                 }
                               },
                               "required": [
                                 "name"
                               ],
                               "type": "object",
+                              "markdownDescription": "Volume that should be mounted to a component container",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "markdownDescription": "List of volumes mounts that should be mounted is this container."
                           }
                         },
                         "required": [
                           "name"
                         ],
                         "type": "object",
+                        "markdownDescription": "Allows adding and configuring workspace-related containers",
                         "additionalProperties": false
                       },
                       "custom": {
@@ -2255,15 +2522,18 @@
                         "properties": {
                           "componentClass": {
                             "description": "Class of component that the associated implementation controller should use to process this command with the appropriate logic",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Class of component that the associated implementation controller should use to process this command with the appropriate logic"
                           },
                           "embeddedResource": {
                             "description": "Additional free-form configuration for this custom component that the implementation controller will know how to use",
-                            "type": "object"
+                            "type": "object",
+                            "markdownDescription": "Additional free-form configuration for this custom component that the implementation controller will know how to use"
                           },
                           "name": {
                             "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                           }
                         },
                         "required": [
@@ -2272,6 +2542,7 @@
                           "name"
                         ],
                         "type": "object",
+                        "markdownDescription": "Custom component whose logic is implementation-dependant and should be provided by the user possibly through some dedicated controller",
                         "additionalProperties": false
                       },
                       "kubernetes": {
@@ -2284,32 +2555,37 @@
                                   "additionalProperties": {
                                     "type": "string"
                                   },
-                                  "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                  "type": "object"
+                                  "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                  "type": "object",
+                                  "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                 },
                                 "exposure": {
-                                  "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                  "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                   "enum": [
                                     "public",
                                     "internal",
                                     "none"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                 },
                                 "name": {
                                   "type": "string"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Path of the endpoint URL"
                                 },
                                 "protocol": {
-                                  "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                  "type": "string"
+                                  "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                  "type": "string",
+                                  "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                 },
                                 "secure": {
                                   "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                 },
                                 "targetPort": {
                                   "type": "integer"
@@ -2325,21 +2601,25 @@
                           },
                           "inlined": {
                             "description": "Inlined manifest",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Inlined manifest"
                           },
                           "name": {
                             "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                           },
                           "uri": {
                             "description": "Location in a file fetched from a uri.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Location in a file fetched from a uri."
                           }
                         },
                         "required": [
                           "name"
                         ],
                         "type": "object",
+                        "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
                         "additionalProperties": false,
                         "oneOf": [
                           {
@@ -2364,32 +2644,37 @@
                                   "additionalProperties": {
                                     "type": "string"
                                   },
-                                  "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                  "type": "object"
+                                  "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                  "type": "object",
+                                  "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                 },
                                 "exposure": {
-                                  "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                  "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                   "enum": [
                                     "public",
                                     "internal",
                                     "none"
                                   ],
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                 },
                                 "name": {
                                   "type": "string"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
-                                  "type": "string"
+                                  "type": "string",
+                                  "markdownDescription": "Path of the endpoint URL"
                                 },
                                 "protocol": {
-                                  "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                  "type": "string"
+                                  "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                  "type": "string",
+                                  "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                 },
                                 "secure": {
                                   "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                 },
                                 "targetPort": {
                                   "type": "integer"
@@ -2405,21 +2690,25 @@
                           },
                           "inlined": {
                             "description": "Inlined manifest",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Inlined manifest"
                           },
                           "name": {
                             "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                           },
                           "uri": {
                             "description": "Location in a file fetched from a uri.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Location in a file fetched from a uri."
                           }
                         },
                         "required": [
                           "name"
                         ],
                         "type": "object",
+                        "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
                         "additionalProperties": false,
                         "oneOf": [
                           {
@@ -2435,32 +2724,35 @@
                         ]
                       },
                       "plugin": {
-                        "description": "Allows importing a plugin. \n Plugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+                        "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                         "properties": {
                           "commands": {
                             "description": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge",
                             "items": {
                               "properties": {
                                 "apply": {
-                                  "description": "Command that consists in applying a given component definition, typically bound to a workspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                                  "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                                   "properties": {
                                     "attributes": {
                                       "additionalProperties": {
                                         "type": "string"
                                       },
                                       "description": "Optional map of free-form additional command attributes",
-                                      "type": "object"
+                                      "type": "object",
+                                      "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "component": {
                                       "description": "Describes component that will be applied",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Describes component that will be applied"
                                     },
                                     "group": {
                                       "description": "Defines the group this command is part of",
                                       "properties": {
                                         "isDefault": {
                                           "description": "Identifies the default command for a given group kind",
-                                          "type": "boolean"
+                                          "type": "boolean",
+                                          "markdownDescription": "Identifies the default command for a given group kind"
                                         },
                                         "kind": {
                                           "description": "Kind of group the command is part of",
@@ -2470,28 +2762,33 @@
                                             "test",
                                             "debug"
                                           ],
-                                          "type": "string"
+                                          "type": "string",
+                                          "markdownDescription": "Kind of group the command is part of"
                                         }
                                       },
                                       "required": [
                                         "kind"
                                       ],
                                       "type": "object",
+                                      "markdownDescription": "Defines the group this command is part of",
                                       "additionalProperties": false
                                     },
                                     "id": {
                                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                     },
                                     "label": {
                                       "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     }
                                   },
                                   "required": [
                                     "id"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
                                   "additionalProperties": false
                                 },
                                 "composite": {
@@ -2502,21 +2799,24 @@
                                         "type": "string"
                                       },
                                       "description": "Optional map of free-form additional command attributes",
-                                      "type": "object"
+                                      "type": "object",
+                                      "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "commands": {
                                       "description": "The commands that comprise this composite command",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "markdownDescription": "The commands that comprise this composite command"
                                     },
                                     "group": {
                                       "description": "Defines the group this command is part of",
                                       "properties": {
                                         "isDefault": {
                                           "description": "Identifies the default command for a given group kind",
-                                          "type": "boolean"
+                                          "type": "boolean",
+                                          "markdownDescription": "Identifies the default command for a given group kind"
                                         },
                                         "kind": {
                                           "description": "Kind of group the command is part of",
@@ -2526,32 +2826,38 @@
                                             "test",
                                             "debug"
                                           ],
-                                          "type": "string"
+                                          "type": "string",
+                                          "markdownDescription": "Kind of group the command is part of"
                                         }
                                       },
                                       "required": [
                                         "kind"
                                       ],
                                       "type": "object",
+                                      "markdownDescription": "Defines the group this command is part of",
                                       "additionalProperties": false
                                     },
                                     "id": {
                                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                     },
                                     "label": {
                                       "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "parallel": {
                                       "description": "Indicates if the sub-commands should be executed concurrently",
-                                      "type": "boolean"
+                                      "type": "boolean",
+                                      "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
                                     }
                                   },
                                   "required": [
                                     "id"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
                                   "additionalProperties": false
                                 },
                                 "custom": {
@@ -2562,22 +2868,26 @@
                                         "type": "string"
                                       },
                                       "description": "Optional map of free-form additional command attributes",
-                                      "type": "object"
+                                      "type": "object",
+                                      "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "commandClass": {
                                       "description": "Class of command that the associated implementation component should use to process this command with the appropriate logic",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Class of command that the associated implementation component should use to process this command with the appropriate logic"
                                     },
                                     "embeddedResource": {
                                       "description": "Additional free-form configuration for this custom command that the implementation component will know how to use",
-                                      "type": "object"
+                                      "type": "object",
+                                      "markdownDescription": "Additional free-form configuration for this custom command that the implementation component will know how to use"
                                     },
                                     "group": {
                                       "description": "Defines the group this command is part of",
                                       "properties": {
                                         "isDefault": {
                                           "description": "Identifies the default command for a given group kind",
-                                          "type": "boolean"
+                                          "type": "boolean",
+                                          "markdownDescription": "Identifies the default command for a given group kind"
                                         },
                                         "kind": {
                                           "description": "Kind of group the command is part of",
@@ -2587,22 +2897,26 @@
                                             "test",
                                             "debug"
                                           ],
-                                          "type": "string"
+                                          "type": "string",
+                                          "markdownDescription": "Kind of group the command is part of"
                                         }
                                       },
                                       "required": [
                                         "kind"
                                       ],
                                       "type": "object",
+                                      "markdownDescription": "Defines the group this command is part of",
                                       "additionalProperties": false
                                     },
                                     "id": {
                                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                     },
                                     "label": {
                                       "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     }
                                   },
                                   "required": [
@@ -2611,6 +2925,7 @@
                                     "id"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin",
                                   "additionalProperties": false
                                 },
                                 "exec": {
@@ -2621,15 +2936,18 @@
                                         "type": "string"
                                       },
                                       "description": "Optional map of free-form additional command attributes",
-                                      "type": "object"
+                                      "type": "object",
+                                      "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "commandLine": {
                                       "description": "The actual command-line string",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "The actual command-line string"
                                     },
                                     "component": {
                                       "description": "Describes component to which given action relates",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Describes component to which given action relates"
                                     },
                                     "env": {
                                       "description": "Optional list of environment variables that have to be set before running the command",
@@ -2649,14 +2967,16 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "markdownDescription": "Optional list of environment variables that have to be set before running the command"
                                     },
                                     "group": {
                                       "description": "Defines the group this command is part of",
                                       "properties": {
                                         "isDefault": {
                                           "description": "Identifies the default command for a given group kind",
-                                          "type": "boolean"
+                                          "type": "boolean",
+                                          "markdownDescription": "Identifies the default command for a given group kind"
                                         },
                                         "kind": {
                                           "description": "Kind of group the command is part of",
@@ -2666,32 +2986,38 @@
                                             "test",
                                             "debug"
                                           ],
-                                          "type": "string"
+                                          "type": "string",
+                                          "markdownDescription": "Kind of group the command is part of"
                                         }
                                       },
                                       "required": [
                                         "kind"
                                       ],
                                       "type": "object",
+                                      "markdownDescription": "Defines the group this command is part of",
                                       "additionalProperties": false
                                     },
                                     "id": {
                                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                     },
                                     "label": {
                                       "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "workingDir": {
                                       "description": "Working directory where the command should be executed",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Working directory where the command should be executed"
                                     }
                                   },
                                   "required": [
                                     "id"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "CLI Command executed in an existing component container",
                                   "additionalProperties": false
                                 },
                                 "vscodeLaunch": {
@@ -2702,14 +3028,16 @@
                                         "type": "string"
                                       },
                                       "description": "Optional map of free-form additional command attributes",
-                                      "type": "object"
+                                      "type": "object",
+                                      "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "group": {
                                       "description": "Defines the group this command is part of",
                                       "properties": {
                                         "isDefault": {
                                           "description": "Identifies the default command for a given group kind",
-                                          "type": "boolean"
+                                          "type": "boolean",
+                                          "markdownDescription": "Identifies the default command for a given group kind"
                                         },
                                         "kind": {
                                           "description": "Kind of group the command is part of",
@@ -2719,32 +3047,38 @@
                                             "test",
                                             "debug"
                                           ],
-                                          "type": "string"
+                                          "type": "string",
+                                          "markdownDescription": "Kind of group the command is part of"
                                         }
                                       },
                                       "required": [
                                         "kind"
                                       ],
                                       "type": "object",
+                                      "markdownDescription": "Defines the group this command is part of",
                                       "additionalProperties": false
                                     },
                                     "id": {
                                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                     },
                                     "inlined": {
                                       "description": "Inlined content of the VsCode configuration",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Inlined content of the VsCode configuration"
                                     },
                                     "uri": {
                                       "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                                     }
                                   },
                                   "required": [
                                     "id"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Command providing the definition of a VsCode launch action",
                                   "additionalProperties": false,
                                   "oneOf": [
                                     {
@@ -2767,14 +3101,16 @@
                                         "type": "string"
                                       },
                                       "description": "Optional map of free-form additional command attributes",
-                                      "type": "object"
+                                      "type": "object",
+                                      "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "group": {
                                       "description": "Defines the group this command is part of",
                                       "properties": {
                                         "isDefault": {
                                           "description": "Identifies the default command for a given group kind",
-                                          "type": "boolean"
+                                          "type": "boolean",
+                                          "markdownDescription": "Identifies the default command for a given group kind"
                                         },
                                         "kind": {
                                           "description": "Kind of group the command is part of",
@@ -2784,32 +3120,38 @@
                                             "test",
                                             "debug"
                                           ],
-                                          "type": "string"
+                                          "type": "string",
+                                          "markdownDescription": "Kind of group the command is part of"
                                         }
                                       },
                                       "required": [
                                         "kind"
                                       ],
                                       "type": "object",
+                                      "markdownDescription": "Defines the group this command is part of",
                                       "additionalProperties": false
                                     },
                                     "id": {
                                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                     },
                                     "inlined": {
                                       "description": "Inlined content of the VsCode configuration",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Inlined content of the VsCode configuration"
                                     },
                                     "uri": {
                                       "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
                                     }
                                   },
                                   "required": [
                                     "id"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Command providing the definition of a VsCode Task",
                                   "additionalProperties": false,
                                   "oneOf": [
                                     {
@@ -2860,7 +3202,8 @@
                                 }
                               ]
                             },
-                            "type": "array"
+                            "type": "array",
+                            "markdownDescription": "Overrides of commands encapsulated in a plugin. Overriding is done using a strategic merge"
                           },
                           "components": {
                             "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge",
@@ -2870,22 +3213,25 @@
                                   "description": "Configuration overriding for a Container component",
                                   "properties": {
                                     "args": {
-                                      "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                                      "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                                     },
                                     "command": {
-                                      "description": "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image.",
+                                      "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
                                     },
                                     "dedicatedPod": {
-                                      "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`",
-                                      "type": "boolean"
+                                      "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                                      "type": "boolean",
+                                      "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`"
                                     },
                                     "endpoints": {
                                       "items": {
@@ -2894,32 +3240,37 @@
                                             "additionalProperties": {
                                               "type": "string"
                                             },
-                                            "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                            "type": "object"
+                                            "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                            "type": "object",
+                                            "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                           },
                                           "exposure": {
-                                            "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                            "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                             "enum": [
                                               "public",
                                               "internal",
                                               "none"
                                             ],
-                                            "type": "string"
+                                            "type": "string",
+                                            "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                           },
                                           "name": {
                                             "type": "string"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
-                                            "type": "string"
+                                            "type": "string",
+                                            "markdownDescription": "Path of the endpoint URL"
                                           },
                                           "protocol": {
-                                            "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                            "type": "string"
+                                            "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                            "type": "string",
+                                            "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                           },
                                           "secure": {
                                             "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                            "type": "boolean"
+                                            "type": "boolean",
+                                            "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                           },
                                           "targetPort": {
                                             "type": "integer"
@@ -2951,7 +3302,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "markdownDescription": "Environment variables used in this container"
                                     },
                                     "image": {
                                       "type": "string"
@@ -2967,7 +3319,8 @@
                                     },
                                     "sourceMapping": {
                                       "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
                                     },
                                     "volumeMounts": {
                                       "description": "List of volumes mounts that should be mounted is this container.",
@@ -2976,26 +3329,31 @@
                                         "properties": {
                                           "name": {
                                             "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                            "type": "string"
+                                            "type": "string",
+                                            "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                           },
                                           "path": {
                                             "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
-                                            "type": "string"
+                                            "type": "string",
+                                            "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`."
                                           }
                                         },
                                         "required": [
                                           "name"
                                         ],
                                         "type": "object",
+                                        "markdownDescription": "Volume that should be mounted to a component container",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "markdownDescription": "List of volumes mounts that should be mounted is this container."
                                     }
                                   },
                                   "required": [
                                     "name"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Configuration overriding for a Container component",
                                   "additionalProperties": false
                                 },
                                 "kubernetes": {
@@ -3008,32 +3366,37 @@
                                             "additionalProperties": {
                                               "type": "string"
                                             },
-                                            "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                            "type": "object"
+                                            "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                            "type": "object",
+                                            "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                           },
                                           "exposure": {
-                                            "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                            "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                             "enum": [
                                               "public",
                                               "internal",
                                               "none"
                                             ],
-                                            "type": "string"
+                                            "type": "string",
+                                            "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                           },
                                           "name": {
                                             "type": "string"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
-                                            "type": "string"
+                                            "type": "string",
+                                            "markdownDescription": "Path of the endpoint URL"
                                           },
                                           "protocol": {
-                                            "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                            "type": "string"
+                                            "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                            "type": "string",
+                                            "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                           },
                                           "secure": {
                                             "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                            "type": "boolean"
+                                            "type": "boolean",
+                                            "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                           },
                                           "targetPort": {
                                             "type": "integer"
@@ -3049,21 +3412,25 @@
                                     },
                                     "inlined": {
                                       "description": "Inlined manifest",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Inlined manifest"
                                     },
                                     "name": {
                                       "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                                     },
                                     "uri": {
                                       "description": "Location in a file fetched from a uri.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Location in a file fetched from a uri."
                                     }
                                   },
                                   "required": [
                                     "name"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Configuration overriding for a Kubernetes component",
                                   "additionalProperties": false,
                                   "oneOf": [
                                     {
@@ -3088,32 +3455,37 @@
                                             "additionalProperties": {
                                               "type": "string"
                                             },
-                                            "description": "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                            "type": "object"
+                                            "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                            "type": "object",
+                                            "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
                                           },
                                           "exposure": {
-                                            "description": "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address. \n Default value is `public`",
+                                            "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
                                             "enum": [
                                               "public",
                                               "internal",
                                               "none"
                                             ],
-                                            "type": "string"
+                                            "type": "string",
+                                            "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                           },
                                           "name": {
                                             "type": "string"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
-                                            "type": "string"
+                                            "type": "string",
+                                            "markdownDescription": "Path of the endpoint URL"
                                           },
                                           "protocol": {
-                                            "description": "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`",
-                                            "type": "string"
+                                            "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                            "type": "string",
+                                            "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`"
                                           },
                                           "secure": {
                                             "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                            "type": "boolean"
+                                            "type": "boolean",
+                                            "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
                                           },
                                           "targetPort": {
                                             "type": "integer"
@@ -3129,21 +3501,25 @@
                                     },
                                     "inlined": {
                                       "description": "Inlined manifest",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Inlined manifest"
                                     },
                                     "name": {
                                       "description": "Mandatory name that allows referencing the component in commands, or inside a parent",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Mandatory name that allows referencing the component in commands, or inside a parent"
                                     },
                                     "uri": {
                                       "description": "Location in a file fetched from a uri.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Location in a file fetched from a uri."
                                     }
                                   },
                                   "required": [
                                     "name"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Configuration overriding for an OpenShift component",
                                   "additionalProperties": false,
                                   "oneOf": [
                                     {
@@ -3163,17 +3539,20 @@
                                   "properties": {
                                     "name": {
                                       "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                                     },
                                     "size": {
                                       "description": "Size of the volume",
-                                      "type": "string"
+                                      "type": "string",
+                                      "markdownDescription": "Size of the volume"
                                     }
                                   },
                                   "required": [
                                     "name"
                                   ],
                                   "type": "object",
+                                  "markdownDescription": "Configuration overriding for a Volume component",
                                   "additionalProperties": false
                                 }
                               },
@@ -3202,11 +3581,13 @@
                                 }
                               ]
                             },
-                            "type": "array"
+                            "type": "array",
+                            "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge"
                           },
                           "id": {
                             "description": "Id in a registry that contains a Devfile yaml file",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Id in a registry that contains a Devfile yaml file"
                           },
                           "kubernetes": {
                             "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -3222,21 +3603,25 @@
                               "name"
                             ],
                             "type": "object",
+                            "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                             "additionalProperties": false
                           },
                           "name": {
                             "description": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Optional name that allows referencing the component in commands, or inside a parent If omitted it will be infered from the location (uri or registryEntry)"
                           },
                           "registryUrl": {
                             "type": "string"
                           },
                           "uri": {
                             "description": "Uri of a Devfile yaml file",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Uri of a Devfile yaml file"
                           }
                         },
                         "type": "object",
+                        "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
                         "additionalProperties": false,
                         "oneOf": [
                           {
@@ -3261,17 +3646,20 @@
                         "properties": {
                           "name": {
                             "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
                           },
                           "size": {
                             "description": "Size of the volume",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Size of the volume"
                           }
                         },
                         "required": [
                           "name"
                         ],
                         "type": "object",
+                        "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
                         "additionalProperties": false
                       }
                     },
@@ -3310,7 +3698,8 @@
                       }
                     ]
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components"
                 },
                 "events": {
                   "description": "Bindings of commands to events. Each command is referred-to by its name.",
@@ -3320,36 +3709,42 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "markdownDescription": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser."
                     },
                     "postStop": {
                       "description": "Names of commands that should be executed after stopping the workspace.",
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "markdownDescription": "Names of commands that should be executed after stopping the workspace."
                     },
                     "preStart": {
                       "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "markdownDescription": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD."
                     },
                     "preStop": {
                       "description": "Names of commands that should be executed before stopping the workspace.",
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "markdownDescription": "Names of commands that should be executed before stopping the workspace."
                     }
                   },
                   "type": "object",
+                  "markdownDescription": "Bindings of commands to events. Each command is referred-to by its name.",
                   "additionalProperties": false
                 },
                 "id": {
                   "description": "Id in a registry that contains a Devfile yaml file",
-                  "type": "string"
+                  "type": "string",
+                  "markdownDescription": "Id in a registry that contains a Devfile yaml file"
                 },
                 "kubernetes": {
                   "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
@@ -3365,6 +3760,7 @@
                     "name"
                   ],
                   "type": "object",
+                  "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                   "additionalProperties": false
                 },
                 "projects": {
@@ -3373,7 +3769,8 @@
                     "properties": {
                       "clonePath": {
                         "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
                       },
                       "custom": {
                         "description": "Project's Custom source",
@@ -3390,6 +3787,7 @@
                           "projectSourceClass"
                         ],
                         "type": "object",
+                        "markdownDescription": "Project's Custom source",
                         "additionalProperties": false
                       },
                       "git": {
@@ -3397,22 +3795,27 @@
                         "properties": {
                           "branch": {
                             "description": "The branch to check",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "The branch to check"
                           },
                           "location": {
                             "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                           },
                           "sparseCheckoutDir": {
                             "description": "Part of project to populate in the working directory.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Part of project to populate in the working directory."
                           },
                           "startPoint": {
                             "description": "The tag or commit id to reset the checked out branch to",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "The tag or commit id to reset the checked out branch to"
                           }
                         },
                         "type": "object",
+                        "markdownDescription": "Project's Git source",
                         "additionalProperties": false
                       },
                       "github": {
@@ -3420,41 +3823,50 @@
                         "properties": {
                           "branch": {
                             "description": "The branch to check",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "The branch to check"
                           },
                           "location": {
                             "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                           },
                           "sparseCheckoutDir": {
                             "description": "Part of project to populate in the working directory.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Part of project to populate in the working directory."
                           },
                           "startPoint": {
                             "description": "The tag or commit id to reset the checked out branch to",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "The tag or commit id to reset the checked out branch to"
                           }
                         },
                         "type": "object",
+                        "markdownDescription": "Project's GitHub source",
                         "additionalProperties": false
                       },
                       "name": {
                         "description": "Project name",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Project name"
                       },
                       "zip": {
                         "description": "Project's Zip source",
                         "properties": {
                           "location": {
                             "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                           },
                           "sparseCheckoutDir": {
                             "description": "Part of project to populate in the working directory.",
-                            "type": "string"
+                            "type": "string",
+                            "markdownDescription": "Part of project to populate in the working directory."
                           }
                         },
                         "type": "object",
+                        "markdownDescription": "Project's Zip source",
                         "additionalProperties": false
                       }
                     },
@@ -3486,17 +3898,20 @@
                       }
                     ]
                   },
-                  "type": "array"
+                  "type": "array",
+                  "markdownDescription": "Projects worked on in the workspace, containing names and sources locations"
                 },
                 "registryUrl": {
                   "type": "string"
                 },
                 "uri": {
                   "description": "Uri of a Devfile yaml file",
-                  "type": "string"
+                  "type": "string",
+                  "markdownDescription": "Uri of a Devfile yaml file"
                 }
               },
               "type": "object",
+              "markdownDescription": "Parent workspace template",
               "additionalProperties": false,
               "oneOf": [
                 {
@@ -3522,7 +3937,8 @@
                 "properties": {
                   "clonePath": {
                     "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
                   },
                   "custom": {
                     "description": "Project's Custom source",
@@ -3539,6 +3955,7 @@
                       "projectSourceClass"
                     ],
                     "type": "object",
+                    "markdownDescription": "Project's Custom source",
                     "additionalProperties": false
                   },
                   "git": {
@@ -3546,22 +3963,27 @@
                     "properties": {
                       "branch": {
                         "description": "The branch to check",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The branch to check"
                       },
                       "location": {
                         "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                       },
                       "sparseCheckoutDir": {
                         "description": "Part of project to populate in the working directory.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Part of project to populate in the working directory."
                       },
                       "startPoint": {
                         "description": "The tag or commit id to reset the checked out branch to",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The tag or commit id to reset the checked out branch to"
                       }
                     },
                     "type": "object",
+                    "markdownDescription": "Project's Git source",
                     "additionalProperties": false
                   },
                   "github": {
@@ -3569,41 +3991,50 @@
                     "properties": {
                       "branch": {
                         "description": "The branch to check",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The branch to check"
                       },
                       "location": {
                         "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                       },
                       "sparseCheckoutDir": {
                         "description": "Part of project to populate in the working directory.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Part of project to populate in the working directory."
                       },
                       "startPoint": {
                         "description": "The tag or commit id to reset the checked out branch to",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "The tag or commit id to reset the checked out branch to"
                       }
                     },
                     "type": "object",
+                    "markdownDescription": "Project's GitHub source",
                     "additionalProperties": false
                   },
                   "name": {
                     "description": "Project name",
-                    "type": "string"
+                    "type": "string",
+                    "markdownDescription": "Project name"
                   },
                   "zip": {
                     "description": "Project's Zip source",
                     "properties": {
                       "location": {
                         "description": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Project's source location address. Should be URL for git and github located projects, or; file:// for zip"
                       },
                       "sparseCheckoutDir": {
                         "description": "Part of project to populate in the working directory.",
-                        "type": "string"
+                        "type": "string",
+                        "markdownDescription": "Part of project to populate in the working directory."
                       }
                     },
                     "type": "object",
+                    "markdownDescription": "Project's Zip source",
                     "additionalProperties": false
                   }
                 },
@@ -3635,10 +4066,12 @@
                   }
                 ]
               },
-              "type": "array"
+              "type": "array",
+              "markdownDescription": "Projects worked on in the workspace, containing names and sources locations"
             }
           },
           "type": "object",
+          "markdownDescription": "Structure of the workspace. This is also the specification of a workspace template.",
           "additionalProperties": false
         }
       },
@@ -3646,6 +4079,7 @@
         "started"
       ],
       "type": "object",
+      "markdownDescription": "DevWorkspaceSpec defines the desired state of DevWorkspace",
       "additionalProperties": false
     },
     "status": {
@@ -3659,23 +4093,28 @@
               "lastTransitionTime": {
                 "description": "Last time the condition transitioned from one status to another.",
                 "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Last time the condition transitioned from one status to another."
               },
               "message": {
                 "description": "Human-readable message indicating details about last transition.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Human-readable message indicating details about last transition."
               },
               "reason": {
                 "description": "Unique, one-word, CamelCase reason for the condition's last transition.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Unique, one-word, CamelCase reason for the condition's last transition."
               },
               "status": {
                 "description": "Phase is the status of the condition. Can be True, False, Unknown.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Phase is the status of the condition. Can be True, False, Unknown."
               },
               "type": {
                 "description": "Type is the type of the condition.",
-                "type": "string"
+                "type": "string",
+                "markdownDescription": "Type is the type of the condition."
               }
             },
             "required": [
@@ -3683,29 +4122,35 @@
               "type"
             ],
             "type": "object",
+            "markdownDescription": "WorkspaceCondition contains details for the current condition of this workspace.",
             "additionalProperties": false
           },
-          "type": "array"
+          "type": "array",
+          "markdownDescription": "Conditions represent the latest available observations of an object's state"
         },
         "ideUrl": {
           "description": "URL at which the Worksace Editor can be joined",
-          "type": "string"
+          "type": "string",
+          "markdownDescription": "URL at which the Worksace Editor can be joined"
         },
         "phase": {
           "type": "string"
         },
         "workspaceId": {
           "description": "Id of the workspace",
-          "type": "string"
+          "type": "string",
+          "markdownDescription": "Id of the workspace"
         }
       },
       "required": [
         "workspaceId"
       ],
       "type": "object",
+      "markdownDescription": "DevWorkspaceStatus defines the observed state of DevWorkspace",
       "additionalProperties": false
     }
   },
   "type": "object",
+  "markdownDescription": "DevWorkspace is the Schema for the devworkspaces API",
   "additionalProperties": false
 }


### PR DESCRIPTION
### What does this PR do?

This PR provides some  fixes to the Json schema generation process, so that basic Markdown can be easily written in the GO source documentation, and correctly rendered both in the website generated documentation and in VSCode hovers proposed by the YAML language server.

### What issues does this PR fix or reference?

No issue

### Is your PR tested? Consider putting some instruction how to test your changes

Yes, on che.openshift.io
