### PR TITLE
Fix wrong naming in Command Group Go definitions

### DIFF
--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -16,20 +16,20 @@ const (
 	CustomCommandType       CommandType = "Custom"
 )
 
-// CommandGroupType describes the kind of command group.
+// CommandGroupKind describes the kind of command group.
 // +kubebuilder:validation:Enum=build;run;test;debug
-type CommandGroupType string
+type CommandGroupKind string
 
 const (
-	BuildCommandGroupType CommandGroupType = "build"
-	RunCommandGroupType   CommandGroupType = "run"
-	TestCommandGroupType  CommandGroupType = "test"
-	DebugCommandGroupType CommandGroupType = "debug"
+	BuildCommandGroupKind CommandGroupKind = "build"
+	RunCommandGroupKind   CommandGroupKind = "run"
+	TestCommandGroupKind  CommandGroupKind = "test"
+	DebugCommandGroupKind CommandGroupKind = "debug"
 )
 
 type CommandGroup struct {
 	// Kind of group the command is part of
-	Kind CommandGroupType `json:"kind"`
+	Kind CommandGroupKind `json:"kind"`
 
 	// +optional
 	// Identifies the default command for a given group kind


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

Fix wrong naming in Command Group Go definitions.

### What issues does this PR fix or reference?

https://github.com/devfile/kubernetes-api/issues/59

### Is your PR tested? Consider putting some instruction how to test your changes

Yes.

#### Docs PR

Docs are not impacted.