### PR TITLE
Add git and openssh in the tooling image

### DIFF
--- a/.devfile/Dockerfile
+++ b/.devfile/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3-alpine
 ARG OPERATOR_SDK_VERSION=v0.17.0
 ENV GOROOT /usr/lib/go
 
-RUN apk add --no-cache --update curl bash jq go \
+RUN apk add --no-cache --update curl bash jq go git openssh \
 && pip3 install yq \
 && pip3 install jsonpatch
 


### PR DESCRIPTION
### What does this PR do?

This PR adds `git` and `openssh` in the tooling image.
`git` is required to perform some of the Go commands under some conditions (especially the `go test` command)

### What issues does this PR fix or reference?

This PR is related to other PR https://github.com/devfile/kubernetes-api/pull/98 which introduces GO tests and add a `run tests` devfile command.

### Is your PR tested?

Yes, on che.penshift.io