### PR TITLE
VolumeMount should require Volume component definition

### DIFF
--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -530,11 +530,10 @@ spec:
                               properties:
                                 name:
                                   description: The volume mount name is the name of
-                                    an existing `Volume` component. If no corresponding
-                                    `Volume` component exist it is implicitly added.
-                                    If several containers mount the same volume name
-                                    then they will reuse the same volume and will
-                                    be able to access to the same files.
+                                    an existing `Volume` component. If several containers
+                                    mount the same volume name then they will reuse
+                                    the same volume and will be able to access to
+                                    the same files.
                                   type: string
                                 path:
                                   description: The path in the component container
@@ -1275,12 +1274,10 @@ spec:
                                           name:
                                             description: The volume mount name is
                                               the name of an existing `Volume` component.
-                                              If no corresponding `Volume` component
-                                              exist it is implicitly added. If several
-                                              containers mount the same volume name
-                                              then they will reuse the same volume
-                                              and will be able to access to the same
-                                              files.
+                                              If several containers mount the same
+                                              volume name then they will reuse the
+                                              same volume and will be able to access
+                                              to the same files.
                                             type: string
                                           path:
                                             description: The path in the component
@@ -2096,12 +2093,10 @@ spec:
                                   properties:
                                     name:
                                       description: The volume mount name is the name
-                                        of an existing `Volume` component. If no corresponding
-                                        `Volume` component exist it is implicitly
-                                        added. If several containers mount the same
-                                        volume name then they will reuse the same
-                                        volume and will be able to access to the same
-                                        files.
+                                        of an existing `Volume` component. If several
+                                        containers mount the same volume name then
+                                        they will reuse the same volume and will be
+                                        able to access to the same files.
                                       type: string
                                     path:
                                       description: The path in the component container
@@ -2862,12 +2857,11 @@ spec:
                                               name:
                                                 description: The volume mount name
                                                   is the name of an existing `Volume`
-                                                  component. If no corresponding `Volume`
-                                                  component exist it is implicitly
-                                                  added. If several containers mount
-                                                  the same volume name then they will
-                                                  reuse the same volume and will be
-                                                  able to access to the same files.
+                                                  component. If several containers
+                                                  mount the same volume name then
+                                                  they will reuse the same volume
+                                                  and will be able to access to the
+                                                  same files.
                                                 type: string
                                               path:
                                                 description: The path in the component

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -497,11 +497,10 @@ spec:
                           properties:
                             name:
                               description: The volume mount name is the name of an
-                                existing `Volume` component. If no corresponding `Volume`
-                                component exist it is implicitly added. If several
-                                containers mount the same volume name then they will
-                                reuse the same volume and will be able to access to
-                                the same files.
+                                existing `Volume` component. If several containers
+                                mount the same volume name then they will reuse the
+                                same volume and will be able to access to the same
+                                files.
                               type: string
                             path:
                               description: The path in the component container where
@@ -1224,11 +1223,9 @@ spec:
                                       name:
                                         description: The volume mount name is the
                                           name of an existing `Volume` component.
-                                          If no corresponding `Volume` component exist
-                                          it is implicitly added. If several containers
-                                          mount the same volume name then they will
-                                          reuse the same volume and will be able to
-                                          access to the same files.
+                                          If several containers mount the same volume
+                                          name then they will reuse the same volume
+                                          and will be able to access to the same files.
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -2008,11 +2005,10 @@ spec:
                               properties:
                                 name:
                                   description: The volume mount name is the name of
-                                    an existing `Volume` component. If no corresponding
-                                    `Volume` component exist it is implicitly added.
-                                    If several containers mount the same volume name
-                                    then they will reuse the same volume and will
-                                    be able to access to the same files.
+                                    an existing `Volume` component. If several containers
+                                    mount the same volume name then they will reuse
+                                    the same volume and will be able to access to
+                                    the same files.
                                   type: string
                                 path:
                                   description: The path in the component container
@@ -2753,12 +2749,10 @@ spec:
                                           name:
                                             description: The volume mount name is
                                               the name of an existing `Volume` component.
-                                              If no corresponding `Volume` component
-                                              exist it is implicitly added. If several
-                                              containers mount the same volume name
-                                              then they will reuse the same volume
-                                              and will be able to access to the same
-                                              files.
+                                              If several containers mount the same
+                                              volume name then they will reuse the
+                                              same volume and will be able to access
+                                              to the same files.
                                             type: string
                                           path:
                                             description: The path in the component

--- a/pkg/apis/workspaces/v1alpha1/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha1/containerComponent.go
@@ -61,7 +61,6 @@ type EnvVar struct {
 // Volume that should be mounted to a component container
 type VolumeMount struct {
 	// The volume mount name is the name of an existing `Volume` component.
-	// If no corresponding `Volume` component exist it is implicitly added.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
 	Name string `json:"name"`

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -532,9 +532,9 @@
                   "description": "Volume that should be mounted to a component container",
                   "properties": {
                     "name": {
-                      "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                      "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
-                      "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                      "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -1271,9 +1271,9 @@
                             "description": "Volume that should be mounted to a component container",
                             "properties": {
                               "name": {
-                                "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
-                                "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                                "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -2211,9 +2211,9 @@
                       "description": "Volume that should be mounted to a component container",
                       "properties": {
                         "name": {
-                          "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                          "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
-                          "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                          "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -2949,9 +2949,9 @@
                                 "description": "Volume that should be mounted to a component container",
                                 "properties": {
                                   "name": {
-                                    "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                    "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
-                                    "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                                    "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -605,9 +605,9 @@
                   "description": "Volume that should be mounted to a component container",
                   "properties": {
                     "name": {
-                      "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                      "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
-                      "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                      "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -1445,9 +1445,9 @@
                             "description": "Volume that should be mounted to a component container",
                             "properties": {
                               "name": {
-                                "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
-                                "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                                "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -2463,9 +2463,9 @@
                       "description": "Volume that should be mounted to a component container",
                       "properties": {
                         "name": {
-                          "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                          "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
-                          "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                          "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -3302,9 +3302,9 @@
                                 "description": "Volume that should be mounted to a component container",
                                 "properties": {
                                   "name": {
-                                    "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                    "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
-                                    "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                                    "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -622,9 +622,9 @@
                       "description": "Volume that should be mounted to a component container",
                       "properties": {
                         "name": {
-                          "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                          "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
-                          "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                          "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -1462,9 +1462,9 @@
                                 "description": "Volume that should be mounted to a component container",
                                 "properties": {
                                   "name": {
-                                    "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                    "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
-                                    "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                                    "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -2480,9 +2480,9 @@
                           "description": "Volume that should be mounted to a component container",
                           "properties": {
                             "name": {
-                              "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                              "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                               "type": "string",
-                              "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                              "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                             },
                             "path": {
                               "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -3319,9 +3319,9 @@
                                     "description": "Volume that should be mounted to a component container",
                                     "properties": {
                                       "name": {
-                                        "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                        "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                         "type": "string",
-                                        "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                                        "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                       },
                                       "path": {
                                         "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -631,9 +631,9 @@
                           "description": "Volume that should be mounted to a component container",
                           "properties": {
                             "name": {
-                              "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                              "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                               "type": "string",
-                              "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                              "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                             },
                             "path": {
                               "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -1471,9 +1471,9 @@
                                     "description": "Volume that should be mounted to a component container",
                                     "properties": {
                                       "name": {
-                                        "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                        "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                         "type": "string",
-                                        "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                                        "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                       },
                                       "path": {
                                         "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -2489,9 +2489,9 @@
                               "description": "Volume that should be mounted to a component container",
                               "properties": {
                                 "name": {
-                                  "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                  "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                   "type": "string",
-                                  "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                                  "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                 },
                                 "path": {
                                   "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",
@@ -3328,9 +3328,9 @@
                                         "description": "Volume that should be mounted to a component container",
                                         "properties": {
                                           "name": {
-                                            "description": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                            "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                             "type": "string",
-                                            "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
+                                            "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                           },
                                           "path": {
                                             "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.",


### PR DESCRIPTION
### What does this PR do?
`VolumeMount` should require `Volume` component definition.
Otherwise, it doesn't make much sense to add it implicitly. 
One of the reasons is that could lead to errors like this:

```yaml
components:
  - container:
      name: cont1
      volumeMounts:
        - name: myvolume
  - container:
      name: cont2
      volumeMounts:
        # I want to use myvolume, but made a typo
        - name: myvoluem

volumes:
   - name: myvolume
```


### What issues does this PR fix or reference?


### Is your PR tested? Consider putting some instruction how to test your changes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
